### PR TITLE
Fix Django pagination

### DIFF
--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -434,6 +434,12 @@ class QuerySet(object):
             if self._document._meta['ordering']:
                 self.order_by(*self._document._meta['ordering'])
 
+            if self._limit is not None:
+                self._cursor_obj.limit(self._limit)
+
+            if self._skip is not None:
+                self._cursor_obj.skip(self._skip)
+
         return self._cursor_obj
 
     @classmethod

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -1377,6 +1377,23 @@ class QuerySetTest(unittest.TestCase):
 
         Post.drop_collection()
 
+    def test_call_after_limits_set(self):
+        """Ensure that re-filtering after slicing works
+        """
+        class Post(Document):
+            title = StringField()
+
+        Post.drop_collection()
+
+        post1 = Post(title="Post 1")
+        post1.save()
+        post2 = Post(title="Post 2")
+        post2.save()
+
+        posts = Post.objects.all()[0:1]
+        self.assertEqual(len(list(posts())), 1)
+
+        Post.drop_collection()
 
 class QTest(unittest.TestCase):
 


### PR DESCRIPTION
Hi,

Commit b2b4456f74d6ffde969aa2078f90a4c3c9bfbcb1 (Merge branch 'new-q-objects' into v0.4) broke pagination with django's Paginator, yielding all matching documents without taking the current page into account. I have been using django's Paginator along with mongoengine without any problems before commit b2b4456f74d6ffde969aa2078f90a4c3c9bfbcb1. This hurts pretty bad on big collections, so I fixed the issue.

What happens is that when using in a template eg {% for msg in page.object_list %} the object_list attribute is a QuerySet which gets called (surely because it is callable(), I did not check closely) before being iterated on, actually resetting the skip and limit on the pymongo cursor.
