### PR TITLE
Multidb. With the v0.4 (branch: multidb)

### DIFF
--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -37,8 +37,8 @@ _connections = {}
 _dbs = {}
 
 def register_connection(alias, name, host='localhost', port=27017, 
-                        is_slave=False, slaves=None, pool_size=1, 
-                        username=None, password=None):
+                        is_slave=False, slaves=None, username=None, 
+                        password=None):
     """Add a connection. 
     
     :param alias: the name that will be used to refer to this connection 
@@ -49,8 +49,6 @@ def register_connection(alias, name, host='localhost', port=27017,
     :param is_slave: whether the connection can act as a slave
     :param slaves: a list of aliases of slave connections; each of these must
         be a registered connection that has :attr:`is_slave` set to ``True``
-    :param pool_size: the size of the connection pool - cannot be used with
-        authentication
     :param username: username to authenticate with
     :param password: password to authenticate with
     """
@@ -61,7 +59,6 @@ def register_connection(alias, name, host='localhost', port=27017,
         'port': port,
         'is_slave': is_slave,
         'slaves': slaves or [],
-        'pool_size': pool_size,
         'username': username,
         'password': password,
     }
@@ -86,7 +83,6 @@ def _get_connection(alias=DEFAULT_CONNECTION_NAME):
             conn = Connection(
                 host=conn_settings['host'], 
                 port=conn_settings['port'],
-                pool_size=conn_settings['pool_size'],
                 slave_okay=conn_settings['is_slave']
             )
             # Create a master slave connection if slaves have been specified

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -1,62 +1,126 @@
 from pymongo import Connection
+from pymongo.master_slave_connection import MasterSlaveConnection
 
 
-__all__ = ['ConnectionError', 'connect']
+__all__ = ['ConnectionError', 'connect', 'register_connection']
 
+"""
+Sample configuration:
 
-_connection_settings = {
-    'host': 'localhost',
-    'port': 27017,
-    'pool_size': 1,
+DATABASES = {
+    'default': {
+        'host': '127.0.0.1',
+        'port': 27017,
+        'slaves': ['slave1', 'slave2']
+    },
+    'slave1': {
+        'host': '127.0.0.1',
+        'port': 28001,
+        'slave': True,
+    },
+    'slave2': {
+        'host': '127.0.0.1',
+        'port': 28002,
+        'slave': True,
+    },
 }
-_connection = None
+"""
 
-_db_name = None
-_db_username = None
-_db_password = None
-_db = None
-
+DEFAULT_CONNECTION_NAME = 'default'
 
 class ConnectionError(Exception):
     pass
 
 
-def _get_connection():
-    global _connection
+_connection_settings = {}
+_connections = {}
+_dbs = {}
+
+def register_connection(alias, name, host='localhost', port=27017, 
+                        is_slave=False, slaves=None, pool_size=1, 
+                        username=None, password=None):
+    """Add a connection. 
+    
+    :param alias: the name that will be used to refer to this connection 
+        throughout MongoEngine
+    :param name: the name of the specific database to use
+    :param host: the host name of the :program:`mongod` instance to connect to
+    :param port: the port that the :program:`mongod` instance is running on
+    :param is_slave: whether the connection can act as a slave
+    :param slaves: a list of aliases of slave connections; each of these must
+        be a registered connection that has :attr:`is_slave` set to ``True``
+    :param pool_size: the size of the connection pool - cannot be used with
+        authentication
+    :param username: username to authenticate with
+    :param password: password to authenticate with
+    """
+    global _connection_settings
+    _connection_settings[alias] = {
+        'name': name,
+        'host': host,
+        'port': port,
+        'is_slave': is_slave,
+        'slaves': slaves or [],
+        'pool_size': pool_size,
+        'username': username,
+        'password': password,
+    }
+
+def _get_connection(alias=DEFAULT_CONNECTION_NAME):
+    global _connections
     # Connect to the database if not already connected
-    if _connection is None:
+    if alias not in _connections:
+        if alias not in _connection_settings:
+            msg = 'Connection with alias "%s" has not been defined'
+            if alias == DEFAULT_CONNECTION_NAME:
+                msg = 'You have not defined a default connection'
+            raise ConnectionError(msg)
+        conn_settings = _connection_settings[alias]
+
+        # Get all the slave connections
+        slaves = []
+        for slave_alias in conn_settings['slaves']:
+            slaves.append(_get_connection(slave_alias))
+
         try:
-            _connection = Connection(**_connection_settings)
-        except:
-            raise ConnectionError('Cannot connect to the database')
-    return _connection
+            conn = Connection(
+                host=conn_settings['host'], 
+                port=conn_settings['port'],
+                pool_size=conn_settings['pool_size'],
+                slave_okay=conn_settings['is_slave']
+            )
+            # Create a master slave connection if slaves have been specified
+            if slaves:
+                conn = MasterSlaveConnection(conn, slaves)
+            _connections[alias] = conn
+        except Exception, e:
+            raise e
+            raise ConnectionError('Cannot connect to database %s' % alias)
+    return _connections[alias]
 
-def _get_db():
-    global _db, _connection
-    # Connect if not already connected
-    if _connection is None:
-        _connection = _get_connection()
 
-    if _db is None:
-        # _db_name will be None if the user hasn't called connect()
-        if _db_name is None:
-            raise ConnectionError('Not connected to the database')
+def _get_db(alias=DEFAULT_CONNECTION_NAME):
+    global _dbs
+    if alias not in _dbs:
+        conn = _get_connection(alias)
+        conn_settings = _connection_settings[alias]
+        _dbs[alias] = conn[conn_settings['name']]
 
-        # Get DB from current connection and authenticate if necessary
-        _db = _connection[_db_name]
-        if _db_username and _db_password:
-            _db.authenticate(_db_username, _db_password)
+        # Authenticate if necessary
+        if conn_settings['username'] and conn_settings['password']:
+            _dbs[alias].authenticate(conn_settings['username'],
+                                     conn_settings['password'])
+    return _dbs[alias]
 
-    return _db
-
-def connect(db, username=None, password=None, **kwargs):
+def connect(name, **kwargs):
     """Connect to the database specified by the 'db' argument. Connection 
     settings may be provided here as well if the database is not running on
     the default port on localhost. If authentication is needed, provide
     username and password arguments as well.
+
+    .. note::
+       In this is now just a shortcut for 
+       :func:`mongoengine.connection.register_connection`, with :attr:`alias`
+       set to ``default``.
     """
-    global _connection_settings, _db_name, _db_username, _db_password
-    _connection_settings.update(kwargs)
-    _db_name = db
-    _db_username = username
-    _db_password = password
+    register_connection(DEFAULT_CONNECTION_NAME, name, **kwargs)

--- a/tests/connnection.py
+++ b/tests/connnection.py
@@ -1,0 +1,44 @@
+import unittest
+import datetime
+import pymongo
+
+import mongoengine.connection
+from mongoengine import *
+from mongoengine.connection import _get_db, _get_connection
+
+
+class ConnectionTest(unittest.TestCase):
+
+    def tearDown(self):
+        mongoengine.connection._connection_settings = {}
+        mongoengine.connection._connections = {}
+        mongoengine.connection._dbs = {}
+    
+    def test_connect(self):
+        """Ensure that the connect() method works properly.
+        """
+        connect('mongoenginetest')
+
+        conn = _get_connection()
+        self.assertTrue(isinstance(conn, pymongo.connection.Connection))
+
+        db = _get_db()
+        self.assertTrue(isinstance(db, pymongo.database.Database))
+        self.assertEqual(db.name, 'mongoenginetest')
+
+    def test_register_connection(self):
+        """Ensure that connections with different aliases may be registered.
+        """
+        register_connection('testdb', 'mongoenginetest2')
+
+        self.assertRaises(ConnectionError, _get_connection)
+        conn = _get_connection('testdb')
+        self.assertTrue(isinstance(conn, pymongo.connection.Connection))
+
+        db = _get_db('testdb')
+        self.assertTrue(isinstance(db, pymongo.database.Database))
+        self.assertEqual(db.name, 'mongoenginetest2')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/document.py
+++ b/tests/document.py
@@ -9,7 +9,7 @@ from mongoengine.connection import _get_db
 class DocumentTest(unittest.TestCase):
     
     def setUp(self):
-        connect(db='mongoenginetest')
+        connect('mongoenginetest')
         self.db = _get_db()
 
         class Person(Document):

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -8,7 +8,7 @@ from mongoengine.connection import _get_db
 class FieldTest(unittest.TestCase):
 
     def setUp(self):
-        connect(db='mongoenginetest')
+        connect('mongoenginetest')
         self.db = _get_db()
 
     def test_default_values(self):

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -9,7 +9,7 @@ from mongoengine import *
 class QuerySetTest(unittest.TestCase):
     
     def setUp(self):
-        connect(db='mongoenginetest')
+        connect('mongoenginetest')
 
         class Person(Document):
             name = StringField()
@@ -553,6 +553,8 @@ class QuerySetTest(unittest.TestCase):
 class QTest(unittest.TestCase):
     
     def test_or_and(self):
+        """Ensure that Q objects may be properly ANDed an ORed together.
+        """
         q1 = Q(name='test')
         q2 = Q(age__gte=18)
 


### PR DESCRIPTION
Hello Harry,
I recode my multi database from the new v0.4 (Master). I add dbs.py with the Database dict configuration.
So, you can put your databases settings in the django settings.py  or in the dbs.py file (directly in mongoengine). The django setings is priority.

This is a starting point for framework-agnostic version.
I will write some documention on "How to use the multidb branch with diferents databases".

As I wrote in my emails, using this version is very simple:
You don't need to put a "connect" in the settings.py. And the connection.py is lighter, I create one dict for "connections_state" and I put all the dbs object in it (still using your "get_identity() implementation").
This has a direct effect on the connection between python (pymongo) and the mongo daemon (mongod). If you look at the connection accepted in the mongo daemon, you will see their are fewer with my version. Thanks to the unique "connection_state" dict.

Let's take a look at my code (branch: multidb).

All the best.

Damian
