### PR TITLE
New QuerySet methods: .exclude(), .all_fields()

### DIFF
--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -867,11 +867,26 @@ class QuerySet(object):
 
 
     def exclude(self, *fields):
+        """Opposite to .only(), exclude some document's fields. ::
+
+            post = BlogPost.objects(...).exclude("comments")
+
+        :param fields: fields to exclude
+        """
         fields = self._fields_to_dbfields(fields)
         self._loaded_fields += QueryFieldList(fields, direction=QueryFieldList.EXCLUDE)
         return self
 
+    def all_fields(self):
+        """Include all fields. Reset all previously calls of .only() and .exclude(). ::
+
+            post = BlogPost.objects(...).exclude("comments").only("title").all_fields()
+        """
+        self._loaded_fields = QueryFieldList(always_include=self._loaded_fields.always_include)
+        return self
+
     def _fields_to_dbfields(self, fields):
+        """Translate fields paths to its db equivalents"""
         ret = []
         for field in fields:
             field = ".".join(f.db_field for f in QuerySet._lookup_field(self._document, field.split('.')))

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -572,6 +572,29 @@ class QuerySetTest(unittest.TestCase):
 
         Email.drop_collection()
 
+    def test_all_fields(self):
+
+        class Email(Document):
+            sender = StringField()
+            to = StringField()
+            subject = StringField()
+            body = StringField()
+            content_type = StringField()
+
+        Email.drop_collection()
+
+        email = Email(sender='me', to='you', subject='From Russia with Love', body='Hello!', content_type='text/plain')
+        email.save()
+
+        obj = Email.objects.exclude('content_type', 'body').only('to', 'body').all_fields().get()
+        self.assertEqual(obj.sender, 'me')
+        self.assertEqual(obj.to, 'you')
+        self.assertEqual(obj.subject, 'From Russia with Love')
+        self.assertEqual(obj.body, 'Hello!')
+        self.assertEqual(obj.content_type, 'text/plain')
+
+        Email.drop_collection()
+
     def test_find_embedded(self):
         """Ensure that an embedded document is properly returned from a query.
         """


### PR DESCRIPTION
Hi,

I've implemented .exclude() and .all_fields() as we've talked about that on IRC.

Just a quick recap:
- .exclude() is basicaly opposite function to .only()
- .exlude() and .only() can be chained, the result is a combination of both
- .all_fields() resets previous .exclude() and/or .only() calls

The tests should be quite self-explanatory.

Thanks again,

A.
