### PR TITLE
Dynamic collection names, abstract base classes and other fixes

### DIFF
--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -294,6 +294,8 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
         # DocumentMetaclass before instantiating CollectionManager object
         new_class = super_new(cls, name, bases, attrs)
         
+        # Allow dynamically-generated collection names. Pass the newly
+        # created class so the callee has access to __module__, etc.
         if callable(collection):
             new_class._meta['collection'] = collection(new_class)
         

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -5,6 +5,8 @@ import sys
 import pymongo
 import pymongo.objectid
 
+from mongoengine import signals
+
 
 _document_registry = {}
 
@@ -362,6 +364,8 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
 class BaseDocument(object):
 
     def __init__(self, **values):
+        signals.pre_init.send(sender=self.__class__, instance=self, values=values)
+        
         self._data = {}
         # Assign default values to instance
         for attr_name in self._fields.keys():
@@ -374,6 +378,8 @@ class BaseDocument(object):
                 setattr(self, attr_name, values.pop(attr_name))
             except AttributeError:
                 pass
+        
+        signals.post_init.send(sender=self.__class__, instance=self)
 
     def validate(self):
         """Ensure that all fields' values are valid and that required fields

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -134,6 +134,13 @@ class DocumentMetaclass(type):
     """
 
     def __new__(cls, name, bases, attrs):
+        # if the document is already defined in the registry, it has 
+        # probably been imported from a different path. instead of
+        # creating a new copy, just return the registered one.
+        global _document_registry
+        if name in _document_registry:
+            return _document_registry[name]
+        
         metaclass = attrs.get('__metaclass__')
         super_new = super(DocumentMetaclass, cls).__new__
         if metaclass and issubclass(metaclass, DocumentMetaclass):
@@ -205,6 +212,7 @@ class DocumentMetaclass(type):
         new_class.add_to_class('MultipleObjectsReturned', exc)
 
         global _document_registry
+        assert name not in _document_registry, "Attempt to register document twice: " + name + ""
         _document_registry[name] = new_class
 
         return new_class

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -296,6 +296,7 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
         
         # Allow dynamically-generated collection names. Pass the newly
         # created class so the callee has access to __module__, etc.
+        collection = new_class._meta['collection']
         if callable(collection):
             new_class._meta['collection'] = collection(new_class)
         

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -232,7 +232,7 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
         for base in bases:
             if hasattr(base, '_meta') and 'collection' in base._meta:
                 collection = base._meta['collection']
-
+                
                 id_field = id_field or base._meta.get('id_field')
                 base_indexes += base._meta.get('indexes', [])
 
@@ -343,6 +343,12 @@ class BaseDocument(object):
                                           field.__class__.__name__ + '"')
             elif field.required:
                 raise ValidationError('Field "%s" is required' % field.name)
+
+    @classmethod
+    def _get_collection_name(cls):
+        """Returns the collection name for this class.
+        """
+        return cls._meta['collection']
 
     @classmethod
     def _get_subclasses(cls):

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -278,7 +278,9 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
         new_class = super_new(cls, name, bases, attrs)
         
         # Provide a default queryset unless one has been manually provided
-        if not hasattr(new_class, 'objects'):
+        # Note: Check for existance in attrs because hasattr assumes it
+        # doesn't exist if any exception is raised, eg when not connected.
+        if 'objects' not in attrs:
             new_class.objects = QuerySetManager()
 
         user_indexes = [QuerySet._build_index_spec(new_class, spec)

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -268,9 +268,9 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
         # Set up collection manager, needs the class to have fields so use
         # DocumentMetaclass before instantiating CollectionManager object
         new_class = super_new(cls, name, bases, attrs)
-
+        
         # Provide a default queryset unless one has been manually provided
-        if not hasattr(new_class, 'objects') and not 'objects' in attrs:
+        if not hasattr(new_class, 'objects'):
             new_class.objects = QuerySetManager()
 
         user_indexes = [QuerySet._build_index_spec(new_class, spec)

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -270,8 +270,7 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
         new_class = super_new(cls, name, bases, attrs)
 
         # Provide a default queryset unless one has been manually provided
-        #if not hasattr(new_class, 'objects'):
-        if 'objects' not in dir(new_class):
+        if not hasattr(new_class, 'objects') and not 'objects' in attrs:
             new_class.objects = QuerySetManager()
 
         user_indexes = [QuerySet._build_index_spec(new_class, spec)

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -11,6 +11,13 @@ _document_registry = {}
 def get_document(name):
     return _document_registry[name]
 
+def clear_document_registry():
+    global _document_registry
+    _document_registry = {}
+
+def unregister_document(name):
+    global _document_registry
+    del _document_registry[name]
 
 class ValidationError(Exception):
     pass
@@ -211,7 +218,6 @@ class DocumentMetaclass(type):
         exc = subclass_exception('MultipleObjectsReturned', base_excs, module)
         new_class.add_to_class('MultipleObjectsReturned', exc)
 
-        global _document_registry
         assert name not in _document_registry, "Attempt to register document twice: " + name + ""
         _document_registry[name] = new_class
 

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -1,5 +1,5 @@
 from pymongo import Connection
-import multiprocessing
+import threading
 
 __all__ = ['ConnectionError', 'connect', 'disconnect']
 
@@ -52,7 +52,11 @@ def _get_db(reconnect=False):
     return _db[identity]
 
 def get_identity():
-    identity = multiprocessing.current_process()._identity
+	# as per http://api.mongodb.org/python/1.6%2B/api/pymongo/database.html
+	# "When sharing a Connection between multiple threads,
+	# each **thread** will need to authenticate separately."
+	
+    identity = threading.current_thread().ident
     identity = 0 if not identity else identity[0]
     return identity
     

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -57,7 +57,7 @@ def get_identity():
 	# each **thread** will need to authenticate separately."
 	
     identity = threading.current_thread().ident
-    identity = 0 if not identity else identity[0]
+    identity = 0 if not identity else identity
     return identity
     
 def connect(db, username=None, password=None, **kwargs):

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -1,7 +1,7 @@
 from pymongo import Connection
 import threading
 
-__all__ = ['ConnectionError', 'connect', 'disconnect']
+__all__ = ['ConnectionError', 'connect', 'disconnect', 'disconnect_current_thread']
 
 
 _connection_defaults = {
@@ -69,3 +69,10 @@ def disconnect():
     _db_username = None
     _db_password = None
     _connection_settings = _connection_defaults.copy()
+
+def disconnect_current_thread():
+    if hasattr(_mongo_cache, 'connection'):
+        _mongo_cache.connection.disconnect( )
+        del _mongo_cache.connection
+    if hasattr(_mongo_cache, 'db'):
+        del _mongo_cache.db

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -1,7 +1,7 @@
 from pymongo import Connection
 import multiprocessing
 
-__all__ = ['ConnectionError', 'connect']
+__all__ = ['ConnectionError', 'connect', 'disconnect']
 
 
 _connection_defaults = {
@@ -69,3 +69,11 @@ def connect(db, username=None, password=None, **kwargs):
     _db_password = password
     return _get_db(reconnect=True)
 
+def disconnect():
+    global _connection_settings, _db_name, _db_username, _db_password, _db
+    _db = {}
+    _connection = {}
+    _db_name = None
+    _db_username = None
+    _db_password = None
+    _connection_settings = _connection_defaults.copy()

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -1,5 +1,5 @@
 from base import (DocumentMetaclass, TopLevelDocumentMetaclass, BaseDocument,
-                  ValidationError)
+                  ValidationError, unregister_document)
 from queryset import OperationError
 from connection import _get_db
 
@@ -117,6 +117,10 @@ class Document(BaseDocument):
         """
         db = _get_db()
         db.drop_collection(cls._meta['collection'])
+
+    @classmethod
+    def unregister(cls):
+        unregister_document(cls.__name__)
 
 
 class MapReduceDocument(object):

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -410,7 +410,7 @@ class DictField(BaseField):
                                   'contain "." or "$" characters')
 
     def lookup_member(self, member_name):
-        return self.basecls(db_field=member_name)
+        return DictField(basecls=self.basecls, db_field=member_name)
 
 class MapField(BaseField):
     """A field that maps a name to a specified field type. Similar to

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -441,7 +441,7 @@ class ReferenceField(BaseField):
             id_ = document
 
         id_ = id_field.to_mongo(id_)
-        collection = self.document_type._meta['collection']
+        collection = self.document_type._get_collection_name()
         return pymongo.dbref.DBRef(collection, id_)
 
     def prepare_query_value(self, op, value):
@@ -493,7 +493,7 @@ class GenericReferenceField(BaseField):
             id_ = document
 
         id_ = id_field.to_mongo(id_)
-        collection = document._meta['collection']
+        collection = document._get_collection_name()
         ref = pymongo.dbref.DBRef(collection, id_)
         return {'_cls': document.__class__.__name__, '_ref': ref}
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -17,7 +17,7 @@ import types
 
 __all__ = ['StringField', 'IntField', 'FloatField', 'BooleanField',
            'DateTimeField', 'EmbeddedDocumentField', 'ListField', 'DictField',
-           'ObjectIdField', 'ReferenceField', 'ValidationError',
+           'ObjectIdField', 'ReferenceField', 'ValidationError', 'MapField',
            'DecimalField', 'URLField', 'GenericReferenceField', 'FileField',
            'BinaryField', 'SortedListField', 'EmailField', 'GeoPointField']
 
@@ -411,6 +411,97 @@ class DictField(BaseField):
 
     def lookup_member(self, member_name):
         return self.basecls(db_field=member_name)
+
+class MapField(BaseField):
+    """A field that maps a name to a specified field type. Similar to
+    a DictField, except the 'value' of each item must match the specified
+    field type.
+    """
+
+    def __init__(self, field, *args, **kwargs):
+        if not isinstance(field, BaseField):
+            raise ValidationError('Argument to MapField constructor must be '
+                                  'a valid field')
+        self.field = field
+        kwargs.setdefault('default', lambda: {})
+        super(MapField, self).__init__(*args, **kwargs)
+
+    def validate(self, value):
+        """Make sure that a list of valid fields is being used.
+        """
+        if not isinstance(value, dict):
+            raise ValidationError('Only dictionaries may be used in a '
+                                  'DictField')
+
+        if any(('.' in k or '$' in k) for k in value):
+            raise ValidationError('Invalid dictionary key name - keys may not '
+                                  'contain "." or "$" characters')
+
+        try:
+            [self.field.validate(item) for item in value.values()]
+        except Exception, err:
+            raise ValidationError('Invalid MapField item (%s)' % str(item))
+
+
+    def lookup_member(self, member_name):
+        return BaseField(db_field=member_name)
+
+    def __get__(self, instance, owner):
+        """Descriptor to automatically dereference references.
+        """
+        if instance is None:
+            # Document class being used rather than a document object
+            return self
+
+        if isinstance(self.field, ReferenceField):
+            referenced_type = self.field.document_type
+            # Get value from document instance if available 
+            value_dict = instance._data.get(self.name)
+            if value_dict:
+                deref_dict = []
+                for key,value in value_dict.iteritems():
+                    # Dereference DBRefs
+                    if isinstance(value, (pymongo.dbref.DBRef)):
+                        value = _get_db().dereference(value)
+                        deref_dict[key] = referenced_type._from_son(value)
+                    else:
+                        deref_dict[key] = value
+                instance._data[self.name] = deref_dict
+
+        if isinstance(self.field, GenericReferenceField):
+            value_dict = instance._data.get(self.name)
+            if value_dict:
+                deref_dict = []
+                for key,value in value_dict.iteritems():
+                    # Dereference DBRefs
+                    if isinstance(value, (dict, pymongo.son.SON)):
+                        deref_dict[key] = self.field.dereference(value)
+                    else:
+                        deref_dict[key] = value
+                instance._data[self.name] = deref_dict
+
+        return super(MapField, self).__get__(instance, owner)
+
+    def to_python(self, value):
+        return dict( [(key,self.field.to_python(item)) for key,item in value.iteritems()] )
+
+    def to_mongo(self, value):
+        return dict( [(key,self.field.to_mongo(item)) for key,item in value.iteritems()] )
+
+    def prepare_query_value(self, op, value):
+        return self.field.prepare_query_value(op, value)
+
+    def lookup_member(self, member_name):
+        return self.field.lookup_member(member_name)
+
+    def _set_owner_document(self, owner_document):
+        self.field.owner_document = owner_document
+        self._owner_document = owner_document
+
+    def _get_owner_document(self, owner_document):
+        self._owner_document = owner_document
+
+    owner_document = property(_get_owner_document, _set_owner_document)
 
 class ReferenceField(BaseField):
     """A reference to a document that will be automatically dereferenced on

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -412,6 +412,16 @@ class DictField(BaseField):
     def lookup_member(self, member_name):
         return DictField(basecls=self.basecls, db_field=member_name)
 
+    def prepare_query_value(self, op, value):
+        # FIXME: get these from a standard place
+        match_operators = ['contains', 'icontains', 'startswith', 
+                           'istartswith', 'endswith', 'iendswith', 
+                           'exact', 'iexact']
+        if op in match_operators:
+            return StringField().prepare_query_value(op, value)
+        else:
+            return super(DictField,self).prepare_query_value(op, value)
+
 class MapField(BaseField):
     """A field that maps a name to a specified field type. Similar to
     a DictField, except the 'value' of each item must match the specified

--- a/mongoengine/signals.py
+++ b/mongoengine/signals.py
@@ -1,0 +1,10 @@
+from pysignals import Signal
+
+pre_init = Signal(providing_args=["instance", "values"])
+post_init = Signal(providing_args=["instance"])
+
+pre_save = Signal(providing_args=["instance"])
+post_save = Signal(providing_args=["instance", "created"])
+
+pre_delete = Signal(providing_args=["instance"])
+post_delete = Signal(providing_args=["instance"])

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(name='mongoengine',
       long_description=LONG_DESCRIPTION,
       platforms=['any'],
       classifiers=CLASSIFIERS,
-      install_requires=['pymongo'],
+      install_requires=['pymongo', 'pysignals'],
       test_suite='tests',
 )

--- a/tests/document.py
+++ b/tests/document.py
@@ -630,8 +630,47 @@ class DocumentTest(unittest.TestCase):
 
         BlogPost.drop_collection()
 
+    def test_abstract_document(self):
+        """Ensure that a document superclass can be marked as abstract
+        thereby not using it as the name for the collection."""
+        
+        class SpecialDocument(Document):
+        	magic = BooleanField( )
+
+        	meta = {
+        		'abstract': True
+        	}
+        
+        class ExtraSpecialDocument(Document):
+        	extra_magic = BooleanField( )
+
+        	meta = {
+        		'abstract': True
+        	}
+        
+        class User(ExtraSpecialDocument):
+        	username = StringField( )
+
+        class FancyUser(User):
+        	fancy = BooleanField( )
+        
+        self.assertFalse('collection' in SpecialDocument._meta)
+        self.assertFalse('collection' in ExtraSpecialDocument._meta)
+        self.assertEqual(User._meta['collection'], 'user')
+        self.assertEqual(FancyUser._meta['collection'], 'user')
+        
+        def create_bad_abstract():
+            class BadAbstract(FancyUser):
+                evil = BooleanField( )
+
+            	meta = {
+            		'abstract': True
+            	}
+        self.assertRaises(ValueError, create_bad_abstract)
+
     def tearDown(self):
         self.Person.drop_collection()
+        clear_document_registry()
 
 
 if __name__ == '__main__':

--- a/tests/document.py
+++ b/tests/document.py
@@ -668,6 +668,47 @@ class DocumentTest(unittest.TestCase):
             	}
         self.assertRaises(ValueError, create_bad_abstract)
 
+    def test_callable_collection_name(self):
+        """Ensure collection names can be callables."""
+        
+        def _make_collection_name(cls):
+            return cls.__name__.lower() + '_augmented'
+        
+        # check it works with a normal document
+        class User(Document):
+            meta = {
+                'collection': _make_collection_name,
+            }
+            
+            username = StringField( )
+        
+        self.assertEqual(User._meta['collection'], 'user_augmented')
+        
+        # and with an abstract class
+        class AbstractUser(Document):
+            meta = {
+                'collection': _make_collection_name,
+                'abstract': True,
+            }
+            
+            username = StringField( )
+        
+        class RealUser(AbstractUser):
+            fancy = BooleanField( )
+        
+        class AnotherRealUser(AbstractUser):
+            fancy = BooleanField( )
+        
+        class InheritedUser(RealUser):
+            fancy = BooleanField( )
+    
+        self.assertEqual(RealUser._meta['collection'], \
+                         'realuser_augmented')
+        self.assertEqual(AnotherRealUser._meta['collection'], \
+                         'anotherrealuser_augmented')
+        self.assertEqual(InheritedUser._meta['collection'], \
+                         'realuser_augmented')
+
     def tearDown(self):
         self.Person.drop_collection()
         clear_document_registry()

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -785,6 +785,32 @@ class FieldTest(unittest.TestCase):
         d2 = D()
         self.assertEqual(d2.data, {})
         self.assertEqual(d2.data2, {})
+    
+    def test_map_field(self):
+        """Ensure that the MapField works."""
+        
+        class SettingBase(EmbeddedDocument):
+            pass
+        
+        class StringSetting(SettingBase):
+            value = StringField()
+        
+        class IntegerSetting(SettingBase):
+            value = IntField()
+        
+        class Extensible(Document):
+            mapping = MapField(EmbeddedDocumentField(SettingBase))
+        
+        e = Extensible()
+        e.mapping['somestring'] = StringSetting( value='foo' )
+        e.mapping['someint'] = IntegerSetting( value=42 )
+        e.save( )
+        
+        e2 = Extensible.objects.get( id=e.id )
+        self.assertTrue( isinstance( e2.mapping['somestring'], StringSetting ) )
+        self.assertTrue( isinstance( e2.mapping['someint'], IntegerSetting ) )
+        
+        Extensible.drop_collection()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -7,11 +7,13 @@ import gridfs
 
 from mongoengine import *
 from mongoengine.connection import _get_db
+from mongoengine.base import clear_document_registry
 
 
 class FieldTest(unittest.TestCase):
 
     def setUp(self):
+        clear_document_registry()
         connect(db='mongoenginetest')
         self.db = _get_db()
 


### PR DESCRIPTION
These commits fix #28 by using the document registry to bail out early and not create duplicate copies of a class that is imported by multiple paths (eg project.app.models and app.models in django).

Document subclasses can now be made 'abstract', so they are not used to name a collection. This allows custom logic to be included in a top level class without requiring all subclasses to share the same collection.

Also included are small patches to allow meta['collections'] to be a callable, allowing a collection name to be generated dynamically at runtime, for example to add application prefixes by the module they are defined in.

My previous fix for checking for the existence of an overridden 'objects' QuerySetManager has also been made cleaner, so it now works when the models are loaded while the database is NOT connected as well.
