### PR TITLE
I have tried to save object with _id equal to 0 and MongoDB created ObjectId instance for me.

### DIFF
--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -442,7 +442,7 @@ class BaseDocument(object):
                 self._meta.get('allow_inheritance', True) == False):
             data['_cls'] = self._class_name
             data['_types'] = self._superclasses.keys() + [self._class_name]
-        if data.has_key('_id') and not data['_id']:
+        if data.has_key('_id') and data['_id'] is None:
             del data['_id']
         return data
 


### PR DESCRIPTION
Traceback:
    File "/usr/local/lib/python2.6/dist-packages/mongoengine/document.py", line 87, in save
      self[id_field] = self._fields[id_field].to_python(object_id)
    File "/usr/local/lib/python2.6/dist-packages/mongoengine/fields.py", line 139, in to_python
      return int(value)
  TypeError: int() argument must be a string or a number, not 'ObjectId'
