### PR TITLE
Added support for delete rules

### DIFF
--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -205,23 +205,22 @@ supplying the :attr:`reverse_delete_rule` attributes on the
 
     class Employee(Document):
         ...
-        profile_page = ReferenceField('ProfilePage', delete_rule=mongoengine.NULLIFY)
+        profile_page = ReferenceField('ProfilePage', reverse_delete_rule=mongoengine.NULLIFY)
 
 Its value can take any of the following constants:
 
 :const:`mongoengine.DO_NOTHING`
-  This is the default and won't do anything.  Deletes are fast, but may
-  cause database inconsistency or dangling references.
+  This is the default and won't do anything.  Deletes are fast, but may cause
+  database inconsistency or dangling references.
 :const:`mongoengine.DENY`
   Deletion is denied if there still exist references to the object being
   deleted.
 :const:`mongoengine.NULLIFY`
-  Any object's fields still referring to the object being deleted are
-  removed (using MongoDB's "unset" operation), effectively nullifying the
-  relationship.
+  Any object's fields still referring to the object being deleted are removed
+  (using MongoDB's "unset" operation), effectively nullifying the relationship.
 :const:`mongoengine.CASCADE`
-  Any object containing fields that are refererring to the object being
-  deleted are deleted first.
+  Any object containing fields that are refererring to the object being deleted
+  are deleted first.
 
 
 Generic reference fields

--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -193,6 +193,7 @@ as the constructor's argument::
     class ProfilePage(Document):
         content = StringField()
 
+
 Dealing with deletion of referred documents
 '''''''''''''''''''''''''''''''''''''''''''
 By default, MongoDB doesn't check the integrity of your data, so deleting
@@ -206,6 +207,11 @@ supplying the :attr:`reverse_delete_rule` attributes on the
     class Employee(Document):
         ...
         profile_page = ReferenceField('ProfilePage', reverse_delete_rule=mongoengine.NULLIFY)
+
+The declaration in this example means that when an :class:`Employee` object is
+removed, the :class:`ProfilePage` that belongs to that employee is removed as
+well.  If a whole batch of employees is removed, all profile pages that are
+linked are removed as well.
 
 Its value can take any of the following constants:
 
@@ -221,6 +227,23 @@ Its value can take any of the following constants:
 :const:`mongoengine.CASCADE`
   Any object containing fields that are refererring to the object being deleted
   are deleted first.
+
+
+.. warning::
+   A safety note on setting up these delete rules!  Since the delete rules are
+   not recorded on the database level by MongoDB itself, but instead at runtime,
+   in-memory, by the MongoEngine module, it is of the upmost importance
+   that the module that declares the relationship is loaded **BEFORE** the
+   delete is invoked.
+   
+   If, for example, the :class:`Employee` object lives in the
+   :mod:`payroll` app, and the :class:`ProfilePage` in the :mod:`people`
+   app, it is extremely important that the :mod:`people` app is loaded
+   before any employee is removed, because otherwise, MongoEngine could
+   never know this relationship exists.
+   
+   In Django, be sure to put all apps that have such delete rule declarations in
+   their :file:`models.py` in the :const:`INSTALLED_APPS` tuple.
 
 
 Generic reference fields

--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -193,6 +193,37 @@ as the constructor's argument::
     class ProfilePage(Document):
         content = StringField()
 
+Dealing with deletion of referred documents
+'''''''''''''''''''''''''''''''''''''''''''
+By default, MongoDB doesn't check the integrity of your data, so deleting
+documents that other documents still hold references to will lead to consistency
+issues.  Mongoengine's :class:`ReferenceField` adds some functionality to
+safeguard against these kinds of database integrity problems, providing each
+reference with a delete rule specification.  A delete rule is specified by
+supplying the :attr:`delete_rule` attribute on the :class:`ReferenceField`
+definition, like this::
+
+    class Employee(Document):
+        ...
+        profile_page = ReferenceField('ProfilePage', delete_rule=mongoengine.NULLIFY)
+
+Its value can take any of the following constants:
+
+:const:`mongoengine.DO_NOTHING`
+  This is the default and won't do anything.  Deletes are fast, but may
+  cause database inconsistency or dangling references.
+:const:`mongoengine.DENY`
+  Deletion is denied if there still exist references to the object being
+  deleted.
+:const:`mongoengine.NULLIFY`
+  Any object's fields still referring to the object being deleted are
+  removed (using MongoDB's "unset" operation), effectively nullifying the
+  relationship.
+:const:`mongoengine.CASCADE`
+  Any object containing fields that are refererring to the object being
+  deleted are deleted first.
+
+
 Generic reference fields
 ''''''''''''''''''''''''
 A second kind of reference field also exists,

--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -200,8 +200,8 @@ documents that other documents still hold references to will lead to consistency
 issues.  Mongoengine's :class:`ReferenceField` adds some functionality to
 safeguard against these kinds of database integrity problems, providing each
 reference with a delete rule specification.  A delete rule is specified by
-supplying the :attr:`delete_rule` attribute on the :class:`ReferenceField`
-definition, like this::
+supplying the :attr:`reverse_delete_rule` attributes on the
+:class:`ReferenceField` definition, like this::
 
     class Employee(Document):
         ...

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -190,6 +190,8 @@ class DocumentMetaclass(type):
         new_class = super_new(cls, name, bases, attrs)
         for field in new_class._fields.values():
             field.owner_document = new_class
+            if hasattr(field, 'delete_rule') and field.delete_rule:
+                field.document_type._meta['delete_rules'][(new_class, field.name)] = field.delete_rule
 
         module = attrs.get('__module__')
 
@@ -258,6 +260,7 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
             'index_drop_dups': False,
             'index_opts': {},
             'queryset_class': QuerySet,
+            'delete_rules': {},
         }
         meta.update(base_meta)
 

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -191,7 +191,8 @@ class DocumentMetaclass(type):
         for field in new_class._fields.values():
             field.owner_document = new_class
             if hasattr(field, 'delete_rule') and field.delete_rule:
-                field.document_type._meta['delete_rules'][(new_class, field.name)] = field.delete_rule
+                field.document_type.register_delete_rule(new_class, field.name,
+                        field.delete_rule)
 
         module = attrs.get('__module__')
 

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -1,5 +1,6 @@
 from queryset import QuerySet, QuerySetManager
 from queryset import DoesNotExist, MultipleObjectsReturned
+from queryset import DO_NOTHING
 
 import sys
 import pymongo
@@ -190,7 +191,7 @@ class DocumentMetaclass(type):
         new_class = super_new(cls, name, bases, attrs)
         for field in new_class._fields.values():
             field.owner_document = new_class
-            if hasattr(field, 'delete_rule') and field.delete_rule:
+            if hasattr(field, 'delete_rule') and field.delete_rule > DO_NOTHING:
                 field.document_type.register_delete_rule(new_class, field.name,
                         field.delete_rule)
 

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -492,6 +492,7 @@ class BaseDocument(object):
 if sys.version_info < (2, 5):
     # Prior to Python 2.5, Exception was an old-style class
     def subclass_exception(name, parents, unused):
+        import types
         return types.ClassType(name, parents, {})
 else:
     def subclass_exception(name, parents, module):

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -191,7 +191,7 @@ class DocumentMetaclass(type):
         new_class = super_new(cls, name, bases, attrs)
         for field in new_class._fields.values():
             field.owner_document = new_class
-            delete_rule = getattr(field, 'delete_rule', DO_NOTHING)
+            delete_rule = getattr(field, 'reverse_delete_rule', DO_NOTHING)
             if delete_rule != DO_NOTHING:
                 field.document_type.register_delete_rule(new_class, field.name,
                         delete_rule)

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -191,9 +191,10 @@ class DocumentMetaclass(type):
         new_class = super_new(cls, name, bases, attrs)
         for field in new_class._fields.values():
             field.owner_document = new_class
-            if hasattr(field, 'delete_rule') and field.delete_rule > DO_NOTHING:
+            delete_rule = getattr(field, 'delete_rule', DO_NOTHING)
+            if delete_rule != DO_NOTHING:
                 field.document_type.register_delete_rule(new_class, field.name,
-                        field.delete_rule)
+                        delete_rule)
 
         module = attrs.get('__module__')
 

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -1,6 +1,6 @@
 from base import (DocumentMetaclass, TopLevelDocumentMetaclass, BaseDocument,
                   ValidationError)
-from queryset import OperationError, DO_NOTHING
+from queryset import OperationError
 from connection import _get_db
 
 import pymongo
@@ -105,9 +105,6 @@ class Document(BaseDocument):
         """This method registers the delete rules to apply when removing this
         object.
         """
-        if rule == DO_NOTHING:
-            return
-
         cls._meta['delete_rules'][(document_cls, field_name)] = rule
 
 

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -1,20 +1,13 @@
 from base import (DocumentMetaclass, TopLevelDocumentMetaclass, BaseDocument,
                   ValidationError)
-from queryset import OperationError
+from queryset import OperationError, DO_NOTHING
 from connection import _get_db
 
 import pymongo
 
 
-__all__ = ['Document', 'EmbeddedDocument', 'ValidationError', 'OperationError',
-        'DO_NOTHING', 'NULLIFY', 'CASCADE', 'DENY']
+__all__ = ['Document', 'EmbeddedDocument', 'ValidationError', 'OperationError']
 
-
-# Delete rules
-DO_NOTHING = 0
-NULLIFY = 1
-CASCADE = 2
-DENY = 3
 
 class EmbeddedDocument(BaseDocument):
     """A :class:`~mongoengine.Document` that isn't stored in its own
@@ -110,7 +103,7 @@ class Document(BaseDocument):
     @classmethod
     def register_delete_rule(cls, document_cls, field_name, rule):
         """This method registers the delete rules to apply when removing this
-        object.  This could go into the Document class.
+        object.
         """
         if rule == DO_NOTHING:
             return

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -105,6 +105,19 @@ class Document(BaseDocument):
 
             if rule == CASCADE:
                 document_cls.objects(**{field_name: self.id}).delete(safe=safe)
+            elif rule == NULLIFY:
+                # TODO: For now, this makes the nullify test pass, but it would
+                # be nicer to use any of these two atomic versions:
+                #
+                #    document_cls.objects(**{field_name: self.id}).update(**{'unset__%s' % field_name: 1})
+                # or
+                #    document_cls.objects(**{field_name: self.id}).update(**{'set__%s' % field_name: None})
+                #
+                # However, I'm getting ValidationError: 1/None is not a valid ObjectId
+                # Anybody got a clue?
+                for doc in document_cls.objects(**{field_name: self.id}):
+                    doc.reviewer = None
+                    doc.save()
 
         id_field = self._meta['id_field']
         object_id = self._fields[id_field].to_mongo(self[id_field])

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -106,18 +106,7 @@ class Document(BaseDocument):
             if rule == CASCADE:
                 document_cls.objects(**{field_name: self.id}).delete(safe=safe)
             elif rule == NULLIFY:
-                # TODO: For now, this makes the nullify test pass, but it would
-                # be nicer to use any of these two atomic versions:
-                #
-                #    document_cls.objects(**{field_name: self.id}).update(**{'unset__%s' % field_name: 1})
-                # or
-                #    document_cls.objects(**{field_name: self.id}).update(**{'set__%s' % field_name: None})
-                #
-                # However, I'm getting ValidationError: 1/None is not a valid ObjectId
-                # Anybody got a clue?
-                for doc in document_cls.objects(**{field_name: self.id}):
-                    doc.reviewer = None
-                    doc.save()
+                document_cls.objects(**{field_name: self.id}).update(**{'unset__%s' % field_name: 1})
 
         id_field = self._meta['id_field']
         object_id = self._fields[id_field].to_mongo(self[id_field])

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -107,7 +107,6 @@ class Document(BaseDocument):
             if rule == DENY and document_cls.objects(**{field_name: self.id}).count() > 0:
                 msg = u'Could not delete document (at least %s.%s refers to it)' % \
                         (document_cls.__name__, field_name)
-                logging.error(msg)
                 raise OperationError(msg)
 
         for rule_entry in self._meta['delete_rules']:

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -99,26 +99,6 @@ class Document(BaseDocument):
 
         :param safe: check if the operation succeeded before returning
         """
-        # Check for DENY rules before actually deleting/nullifying any other
-        # references
-        for rule_entry in self._meta['delete_rules']:
-            document_cls, field_name = rule_entry
-            rule = self._meta['delete_rules'][rule_entry]
-            if rule == DENY and document_cls.objects(**{field_name: self.id}).count() > 0:
-                msg = u'Could not delete document (at least %s.%s refers to it)' % \
-                        (document_cls.__name__, field_name)
-                raise OperationError(msg)
-
-        for rule_entry in self._meta['delete_rules']:
-            document_cls, field_name = rule_entry
-            rule = self._meta['delete_rules'][rule_entry]
-
-            if rule == CASCADE:
-                document_cls.objects(**{field_name: self.id}).delete(safe=safe)
-            elif rule == NULLIFY:
-                document_cls.objects(**{field_name:
-                    self.id}).update(**{'unset__%s' % field_name: 1})
-
         id_field = self._meta['id_field']
         object_id = self._fields[id_field].to_mongo(self[id_field])
         try:

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -99,6 +99,17 @@ class Document(BaseDocument):
 
         :param safe: check if the operation succeeded before returning
         """
+        # Check for DENY rules before actually deleting/nullifying any other
+        # references
+        for rule_entry in self._meta['delete_rules']:
+            document_cls, field_name = rule_entry
+            rule = self._meta['delete_rules'][rule_entry]
+            if rule == DENY and document_cls.objects(**{field_name: self.id}).count() > 0:
+                msg = u'Could not delete document (at least %s.%s refers to it)' % \
+                        (document_cls.__name__, field_name)
+                logging.error(msg)
+                raise OperationError(msg)
+
         for rule_entry in self._meta['delete_rules']:
             document_cls, field_name = rule_entry
             rule = self._meta['delete_rules'][rule_entry]
@@ -106,7 +117,8 @@ class Document(BaseDocument):
             if rule == CASCADE:
                 document_cls.objects(**{field_name: self.id}).delete(safe=safe)
             elif rule == NULLIFY:
-                document_cls.objects(**{field_name: self.id}).update(**{'unset__%s' % field_name: 1})
+                document_cls.objects(**{field_name:
+                    self.id}).update(**{'unset__%s' % field_name: 1})
 
         id_field = self._meta['id_field']
         object_id = self._fields[id_field].to_mongo(self[id_field])

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -1,4 +1,5 @@
 from base import BaseField, ObjectIdField, ValidationError, get_document
+from queryset import DO_NOTHING
 from document import Document, EmbeddedDocument
 from connection import _get_db
 from operator import itemgetter
@@ -417,7 +418,7 @@ class ReferenceField(BaseField):
     access (lazily).
     """
 
-    def __init__(self, document_type, delete_rule=None, **kwargs):
+    def __init__(self, document_type, delete_rule=DO_NOTHING, **kwargs):
         if not isinstance(document_type, basestring):
             if not issubclass(document_type, (Document, basestring)):
                 raise ValidationError('Argument to ReferenceField constructor '

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -418,13 +418,13 @@ class ReferenceField(BaseField):
     access (lazily).
     """
 
-    def __init__(self, document_type, delete_rule=DO_NOTHING, **kwargs):
+    def __init__(self, document_type, reverse_delete_rule=DO_NOTHING, **kwargs):
         if not isinstance(document_type, basestring):
             if not issubclass(document_type, (Document, basestring)):
                 raise ValidationError('Argument to ReferenceField constructor '
                                       'must be a document class or a string')
         self.document_type_obj = document_type
-        self.delete_rule = delete_rule
+        self.reverse_delete_rule = reverse_delete_rule
         super(ReferenceField, self).__init__(**kwargs)
 
     @property

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -417,12 +417,13 @@ class ReferenceField(BaseField):
     access (lazily).
     """
 
-    def __init__(self, document_type, **kwargs):
+    def __init__(self, document_type, delete_rule=None, **kwargs):
         if not isinstance(document_type, basestring):
             if not issubclass(document_type, (Document, basestring)):
                 raise ValidationError('Argument to ReferenceField constructor '
                                       'must be a document class or a string')
         self.document_type_obj = document_type
+        self.delete_rule = delete_rule
         super(ReferenceField, self).__init__(**kwargs)
 
     @property

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -907,7 +907,9 @@ class QuerySet(object):
             if rule == CASCADE:
                 document_cls.objects(**{field_name + '__in': self}).delete(safe=safe)
             elif rule == NULLIFY:
-                document_cls.objects(**{field_name + '__in': self}).update(**{'unset__%s' % field_name: 1})
+                document_cls.objects(**{field_name + '__in': self}).update(
+                        safe_update=safe,
+                        **{'unset__%s' % field_name: 1})
 
         self._collection.remove(self._query, safe=safe)
 

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -10,10 +10,17 @@ import copy
 import itertools
 
 __all__ = ['queryset_manager', 'Q', 'InvalidQueryError',
-           'InvalidCollectionError']
+           'InvalidCollectionError', 'DO_NOTHING', 'NULLIFY', 'CASCADE', 'DENY']
+
 
 # The maximum number of items to display in a QuerySet.__repr__
 REPR_OUTPUT_SIZE = 20
+
+# Delete rules
+DO_NOTHING = 0
+NULLIFY = 1
+CASCADE = 2
+DENY = 3
 
 
 class DoesNotExist(Exception):
@@ -882,8 +889,6 @@ class QuerySet(object):
 
         :param safe: check if the operation succeeded before returning
         """
-        from document import CASCADE, DENY, NULLIFY
-
         doc = self._document
 
         # Check for DENY rules before actually deleting/nullifying any other

--- a/tests/document.py
+++ b/tests/document.py
@@ -624,6 +624,31 @@ class DocumentTest(unittest.TestCase):
 
         BlogPost.drop_collection()
 
+
+    def test_cascade_delete(self):
+        """Ensure that a referenced document is also deleted upon deletion.
+        """
+
+        class BlogPost(Document):
+            meta = {'collection': 'blogpost_1'}
+            content = StringField()
+            author = ReferenceField(self.Person, delete_rule=CASCADE)
+
+        self.Person.drop_collection()
+        BlogPost.drop_collection()
+
+        author = self.Person(name='Test User')
+        author.save()
+
+        post = BlogPost(content = 'Watched some TV')
+        post.author = author
+        post.save()
+
+        # Delete the Person, which should lead to deletion of the BlogPost, too
+        author.delete()
+        self.assertEqual(len(BlogPost.objects), 0)
+
+
     def tearDown(self):
         self.Person.drop_collection()
 

--- a/tests/document.py
+++ b/tests/document.py
@@ -502,7 +502,7 @@ class DocumentTest(unittest.TestCase):
         try:
             recipient.save(validate=False)
         except ValidationError:
-            fail()
+            self.fail()
 
     def test_delete(self):
         """Ensure that document may be deleted using the delete method.

--- a/tests/document.py
+++ b/tests/document.py
@@ -625,14 +625,14 @@ class DocumentTest(unittest.TestCase):
         BlogPost.drop_collection()
 
 
-    def test_delete_rule_cascade_and_nullify(self):
+    def test_reverse_delete_rule_cascade_and_nullify(self):
         """Ensure that a referenced document is also deleted upon deletion.
         """
 
         class BlogPost(Document):
             content = StringField()
-            author = ReferenceField(self.Person, delete_rule=CASCADE)
-            reviewer = ReferenceField(self.Person, delete_rule=NULLIFY)
+            author = ReferenceField(self.Person, reverse_delete_rule=CASCADE)
+            reviewer = ReferenceField(self.Person, reverse_delete_rule=NULLIFY)
 
         self.Person.drop_collection()
         BlogPost.drop_collection()
@@ -656,18 +656,18 @@ class DocumentTest(unittest.TestCase):
         author.delete()
         self.assertEqual(len(BlogPost.objects), 0)
 
-    def test_delete_rule_cascade_recurs(self):
+    def test_reverse_delete_rule_cascade_recurs(self):
         """Ensure that a chain of documents is also deleted upon cascaded
         deletion.
         """
 
         class BlogPost(Document):
             content = StringField()
-            author = ReferenceField(self.Person, delete_rule=CASCADE)
+            author = ReferenceField(self.Person, reverse_delete_rule=CASCADE)
 
         class Comment(Document):
             text = StringField()
-            post = ReferenceField(BlogPost, delete_rule=CASCADE)
+            post = ReferenceField(BlogPost, reverse_delete_rule=CASCADE)
 
 
         author = self.Person(name='Test User')
@@ -690,14 +690,14 @@ class DocumentTest(unittest.TestCase):
         BlogPost.drop_collection()
         Comment.drop_collection()
 
-    def test_delete_rule_deny(self):
+    def test_reverse_delete_rule_deny(self):
         """Ensure that a document cannot be referenced if there are still
         documents referring to it.
         """
 
         class BlogPost(Document):
             content = StringField()
-            author = ReferenceField(self.Person, delete_rule=DENY)
+            author = ReferenceField(self.Person, reverse_delete_rule=DENY)
 
         self.Person.drop_collection()
         BlogPost.drop_collection()

--- a/tests/document.py
+++ b/tests/document.py
@@ -630,7 +630,6 @@ class DocumentTest(unittest.TestCase):
         """
 
         class BlogPost(Document):
-            meta = {'collection': 'blogpost_1'}
             content = StringField()
             author = ReferenceField(self.Person, delete_rule=CASCADE)
             reviewer = ReferenceField(self.Person, delete_rule=NULLIFY)

--- a/tests/document.py
+++ b/tests/document.py
@@ -657,6 +657,18 @@ class DocumentTest(unittest.TestCase):
         author.delete()
         self.assertEqual(len(BlogPost.objects), 0)
 
+    def test_delete_rule_cascade_recurs(self):
+        """Ensure that a recursive chain of documents is also deleted upon
+        cascaded deletion.
+        """
+        self.fail()
+
+    def test_delete_rule_deny(self):
+        """Ensure that a document cannot be referenced if there are still
+        documents referring to it.
+        """
+        self.fail()
+
 
     def tearDown(self):
         self.Person.drop_collection()

--- a/tests/document.py
+++ b/tests/document.py
@@ -658,8 +658,8 @@ class DocumentTest(unittest.TestCase):
         self.assertEqual(len(BlogPost.objects), 0)
 
     def test_delete_rule_cascade_recurs(self):
-        """Ensure that a recursive chain of documents is also deleted upon
-        cascaded deletion.
+        """Ensure that a chain of documents is also deleted upon cascaded
+        deletion.
         """
         self.fail()
 

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -523,29 +523,29 @@ class FieldTest(unittest.TestCase):
         Link.drop_collection()
         Post.drop_collection()
         Bookmark.drop_collection()
-    
+
         link_1 = Link(title="Pitchfork")
         link_1.save()
-    
+
         post_1 = Post(title="Behind the Scenes of the Pavement Reunion")
         post_1.save()
-        
+
         bm = Bookmark(bookmark_object=post_1)
         bm.save()
-        
+
         bm = Bookmark.objects(bookmark_object=post_1).first()
-        
+
         self.assertEqual(bm.bookmark_object, post_1)
         self.assertTrue(isinstance(bm.bookmark_object, Post))
-        
+
         bm.bookmark_object = link_1
         bm.save()
-        
+
         bm = Bookmark.objects(bookmark_object=link_1).first()
-        
+
         self.assertEqual(bm.bookmark_object, link_1)
         self.assertTrue(isinstance(bm.bookmark_object, Link))
-    
+
         Link.drop_collection()
         Post.drop_collection()
         Bookmark.drop_collection()
@@ -555,23 +555,23 @@ class FieldTest(unittest.TestCase):
         """
         class Link(Document):
             title = StringField()
-    
+
         class Post(Document):
             title = StringField()
-    
+
         class User(Document):
             bookmarks = ListField(GenericReferenceField())
-    
+
         Link.drop_collection()
         Post.drop_collection()
         User.drop_collection()
-    
+
         link_1 = Link(title="Pitchfork")
         link_1.save()
-    
+
         post_1 = Post(title="Behind the Scenes of the Pavement Reunion")
         post_1.save()
-    
+
         user = User(bookmarks=[post_1, link_1])
         user.save()
         

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -734,12 +734,12 @@ class QuerySetTest(unittest.TestCase):
         self.Person.objects.delete()
         self.assertEqual(len(self.Person.objects), 0)
 
-    def test_delete_rule_cascade(self):
+    def test_reverse_delete_rule_cascade(self):
         """Ensure cascading deletion of referring documents from the database.
         """
         class BlogPost(Document):
             content = StringField()
-            author = ReferenceField(self.Person, delete_rule=CASCADE)
+            author = ReferenceField(self.Person, reverse_delete_rule=CASCADE)
         BlogPost.drop_collection()
 
         me = self.Person(name='Test User')
@@ -755,7 +755,7 @@ class QuerySetTest(unittest.TestCase):
         self.Person.objects(name='Test User').delete()
         self.assertEqual(1, BlogPost.objects.count())
 
-    def test_delete_rule_nullify(self):
+    def test_reverse_delete_rule_nullify(self):
         """Ensure nullification of references to deleted documents.
         """
         class Category(Document):
@@ -763,7 +763,7 @@ class QuerySetTest(unittest.TestCase):
 
         class BlogPost(Document):
             content = StringField()
-            category = ReferenceField(Category, delete_rule=NULLIFY)
+            category = ReferenceField(Category, reverse_delete_rule=NULLIFY)
 
         BlogPost.drop_collection()
         Category.drop_collection()
@@ -780,13 +780,13 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(1, BlogPost.objects.count())
         self.assertEqual(None, BlogPost.objects.first().category)
 
-    def test_delete_rule_deny(self):
+    def test_reverse_delete_rule_deny(self):
         """Ensure deletion gets denied on documents that still have references
         to them.
         """
         class BlogPost(Document):
             content = StringField()
-            author = ReferenceField(self.Person, delete_rule=DENY)
+            author = ReferenceField(self.Person, reverse_delete_rule=DENY)
 
         BlogPost.drop_collection()
         self.Person.drop_collection()

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -351,8 +351,6 @@ class QuerySetTest(unittest.TestCase):
     def test_filter_chaining(self):
         """Ensure filters can be chained together.
         """
-        from datetime import datetime
-
         class BlogPost(Document):
             title = StringField()
             is_published = BooleanField()

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -734,6 +734,21 @@ class QuerySetTest(unittest.TestCase):
         self.Person.objects.delete()
         self.assertEqual(len(self.Person.objects), 0)
 
+    def test_delete_rule_cascade(self):
+        """Ensure cascading deletion of referring documents from the database.
+        """
+        self.fail()
+
+    def test_delete_rule_nullify(self):
+        """Ensure nullification of references to deleted documents.
+        """
+        self.fail()
+
+    def test_delete_rule_deny(self):
+        """Ensure deletion gets denied on documents that still have references to them.
+        """
+        self.fail()
+
     def test_update(self):
         """Ensure that atomic updates work properly.
         """

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -737,7 +737,20 @@ class QuerySetTest(unittest.TestCase):
     def test_delete_rule_cascade(self):
         """Ensure cascading deletion of referring documents from the database.
         """
-        self.fail()
+        class BlogPost(Document):
+            content = StringField()
+            author = ReferenceField(self.Person, delete_rule=CASCADE)
+        BlogPost.drop_collection()
+
+        me = self.Person(name='Test User')
+        me.save()
+
+        post = BlogPost(content='Watching TV', author=me)
+        post.save()
+
+        self.assertEqual(1, BlogPost.objects.count())
+        self.Person.objects.delete()
+        self.assertEqual(0, BlogPost.objects.count())
 
     def test_delete_rule_nullify(self):
         """Ensure nullification of references to deleted documents.

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -744,13 +744,16 @@ class QuerySetTest(unittest.TestCase):
 
         me = self.Person(name='Test User')
         me.save()
+        someoneelse = self.Person(name='Some-one Else')
+        someoneelse.save()
 
-        post = BlogPost(content='Watching TV', author=me)
-        post.save()
+        BlogPost(content='Watching TV', author=me).save()
+        BlogPost(content='Chilling out', author=me).save()
+        BlogPost(content='Pro Testing', author=someoneelse).save()
 
+        self.assertEqual(3, BlogPost.objects.count())
+        self.Person.objects(name='Test User').delete()
         self.assertEqual(1, BlogPost.objects.count())
-        self.Person.objects.delete()
-        self.assertEqual(0, BlogPost.objects.count())
 
     def test_delete_rule_nullify(self):
         """Ensure nullification of references to deleted documents.


### PR DESCRIPTION
I've added the `reverse_delete_rule` argument to the `ReferenceField` constructor, so that it's easy to set up relationship deletion behaviour like cascade, nullify, or deny.

There are tests and documentation, too.
