### PR TITLE
fix for slicing in middle of resultset and also order_by with custom db_field

### DIFF
--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -919,6 +919,10 @@ class QuerySet(object):
             if key[0] in ('-', '+'):
                 key = key[1:]
             key = key.replace('__', '.')
+            try:
+                key = QuerySet._translate_field_name(self._document, key)
+            except:
+                pass
             key_list.append((key, direction))
 
         self._ordering = key_list

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -831,8 +831,10 @@ class QuerySet(object):
         # Slice provided
         if isinstance(key, slice):
             try:
+                stop = key.stop or 0
+                start  = key.start or 0
                 self._cursor_obj = self._cursor[key]
-                self._skip, self._limit = key.start, key.stop
+                self._skip, self._limit = key.start, stop - start if key.stop else key.stop
             except IndexError, err:
                 # PyMongo raises an error if key.start == key.stop, catch it,
                 # bin it, kill it. 

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -1452,6 +1452,8 @@ class QuerySetTest(unittest.TestCase):
         class Test(Document):
             testdict = DictField()
 
+        Test.drop_collection()
+        
         t = Test(testdict={'f': 'Value'})
         t.save()
 

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -1619,7 +1619,25 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(len(list(posts())), 1)
 
         Post.drop_collection()
+        
+    def test_call_with_slice_in_middle(self):
+        """ Ensure that refiltering works after slicing in middle
+        """
 
+        class Post(Document):
+            title = StringField()
+            
+        Post.drop_collection()
+        
+        for i in range(0,10):
+            post = Post(title="Post %d" % i)
+            post.save()
+            
+        posts = Post.objects.all()[4:6]
+        self.assertEqual(len(list(posts())),2)
+        
+        Post.drop_collection()
+        
     def test_order_then_filter(self):
         """Ensure that ordering still works after filtering.
         """

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -1677,7 +1677,20 @@ class QuerySetTest(unittest.TestCase):
 
         Comment.drop_collection()
         Post.drop_collection()
-
+        
+    def test_order_works_with_custom_db_field_names(self):
+        class Number(Document):
+            n = IntField(db_field='number')
+            
+        Number.drop_collection()
+        
+        n2 = Number.objects.create(n=2)
+        n1 = Number.objects.create(n=1)
+        
+        self.assertEqual(list(Number.objects), [n2,n1])
+        self.assertEqual(list(Number.objects.order_by('n')), [n1,n2])
+            
+        Number.drop_collection()
 
 class QTest(unittest.TestCase):
 


### PR DESCRIPTION
Hi There, 
  I came across a couple issues when I was using Pagination in django.  They had to do with slicing as well as I was using some shortened db_field names.  This lead to the issue I found in order_by.  Not sure if they are the best solutions that I put forward put they make the tests pass :)
