### PR TITLE
Implementing Write Concern

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -68,6 +68,8 @@ class Document(BaseDocument):
         :meth:`~pymongo.collection.Collection.insert` which will be used as options for the resultant ``getLastError`` command.
         For example, ``save(..., w=2, fsync=True)`` will wait until at least two servers
         have recorded the write and will force an fsync on each server being written to.
+        
+        .. note:: Extra keyword arguments require pymongo version 1.8 or higher
 
         :param safe: check if the operation succeeded before returning
         :param force_insert: only try to create a new document, don't allow 

--- a/tests/document.py
+++ b/tests/document.py
@@ -634,7 +634,10 @@ class DocumentTest(unittest.TestCase):
         BlogPost.drop_collection()
 
         author = self.Person(name='Test User')
-        author.save(fsync=True)
+        if float(pymongo.version) >= 1.8:
+            author.save(fsync=True)
+        else:
+            self.assertRaises(TypeError, author.save, fsync=True)
 
     def tearDown(self):
         self.Person.drop_collection()

--- a/tests/document.py
+++ b/tests/document.py
@@ -623,6 +623,18 @@ class DocumentTest(unittest.TestCase):
         self.assertEqual(author.age, 25)
 
         BlogPost.drop_collection()
+        
+    def test_fsync(self):
+        """Test that passing fsync kwarg to .save works"""
+        class BlogPost(Document):
+            meta = {'collection': 'blogpost_1'}
+            content = StringField()
+            author = ReferenceField(self.Person)
+
+        BlogPost.drop_collection()
+
+        author = self.Person(name='Test User')
+        author.save(fsync=True)
 
     def tearDown(self):
         self.Person.drop_collection()


### PR DESCRIPTION
I have added a patch which adds kwargs to the Document.save method which are simply passed to pymongo.collection.Collection.save/insert which allows for options like fsync which can address write concern. Pymongo supports the options out of the box, but I feel mongoengine needs a way to tap into it.

Note this is just working on Document.save but should also be implemented in QuerySet.update/update_one but because it treats kwargs as the document spec, I couldnt think of a good way to force that functionality in there. Any thoughts?
