### PR TITLE
Generalized User class to support subclassing

### DIFF
--- a/mongoengine/django/auth.py
+++ b/mongoengine/django/auth.py
@@ -86,7 +86,7 @@ class User(Document):
             else:
                 email = '@'.join([email_name, domain_part.lower()])
 
-        user = User(username=username, email=email, date_joined=now)
+        user = cls(username=username, email=email, date_joined=now)
         user.set_password(password)
         user.save()
         return user


### PR DESCRIPTION
Hello hmarr, 

User.create_user referenced the User class instead of cls. I subclassed User, but calls to CustomUser.create_user return instances of User without the attached patch.

Thanks for you hard work and contributions to the field. 

Sincerely, 
Cesar Toscano
