### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ build/
 dist/
 mongoengine.egg-info/
 env/
+.settings
 .project
 .pydevproject

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build/
 dist/
 mongoengine.egg-info/
 env/
+.project
+.pydevproject

--- a/docs/apireference.rst
+++ b/docs/apireference.rst
@@ -41,6 +41,8 @@ Fields
 
 .. autoclass:: mongoengine.URLField
 
+.. autoclass:: mongoengine.EmailField
+
 .. autoclass:: mongoengine.IntField
 
 .. autoclass:: mongoengine.FloatField
@@ -56,6 +58,8 @@ Fields
 .. autoclass:: mongoengine.DictField
 
 .. autoclass:: mongoengine.ListField
+
+.. autoclass:: mongoengine.SortedListField
 
 .. autoclass:: mongoengine.BinaryField
 

--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -205,23 +205,22 @@ supplying the :attr:`reverse_delete_rule` attributes on the
 
     class Employee(Document):
         ...
-        profile_page = ReferenceField('ProfilePage', delete_rule=mongoengine.NULLIFY)
+        profile_page = ReferenceField('ProfilePage', reverse_delete_rule=mongoengine.NULLIFY)
 
 Its value can take any of the following constants:
 
 :const:`mongoengine.DO_NOTHING`
-  This is the default and won't do anything.  Deletes are fast, but may
-  cause database inconsistency or dangling references.
+  This is the default and won't do anything.  Deletes are fast, but may cause
+  database inconsistency or dangling references.
 :const:`mongoengine.DENY`
   Deletion is denied if there still exist references to the object being
   deleted.
 :const:`mongoengine.NULLIFY`
-  Any object's fields still referring to the object being deleted are
-  removed (using MongoDB's "unset" operation), effectively nullifying the
-  relationship.
+  Any object's fields still referring to the object being deleted are removed
+  (using MongoDB's "unset" operation), effectively nullifying the relationship.
 :const:`mongoengine.CASCADE`
-  Any object containing fields that are refererring to the object being
-  deleted are deleted first.
+  Any object containing fields that are refererring to the object being deleted
+  are deleted first.
 
 
 Generic reference fields

--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -193,6 +193,7 @@ as the constructor's argument::
     class ProfilePage(Document):
         content = StringField()
 
+
 Dealing with deletion of referred documents
 '''''''''''''''''''''''''''''''''''''''''''
 By default, MongoDB doesn't check the integrity of your data, so deleting
@@ -206,6 +207,11 @@ supplying the :attr:`reverse_delete_rule` attributes on the
     class Employee(Document):
         ...
         profile_page = ReferenceField('ProfilePage', reverse_delete_rule=mongoengine.NULLIFY)
+
+The declaration in this example means that when an :class:`Employee` object is
+removed, the :class:`ProfilePage` that belongs to that employee is removed as
+well.  If a whole batch of employees is removed, all profile pages that are
+linked are removed as well.
 
 Its value can take any of the following constants:
 
@@ -221,6 +227,23 @@ Its value can take any of the following constants:
 :const:`mongoengine.CASCADE`
   Any object containing fields that are refererring to the object being deleted
   are deleted first.
+
+
+.. warning::
+   A safety note on setting up these delete rules!  Since the delete rules are
+   not recorded on the database level by MongoDB itself, but instead at runtime,
+   in-memory, by the MongoEngine module, it is of the upmost importance
+   that the module that declares the relationship is loaded **BEFORE** the
+   delete is invoked.
+   
+   If, for example, the :class:`Employee` object lives in the
+   :mod:`payroll` app, and the :class:`ProfilePage` in the :mod:`people`
+   app, it is extremely important that the :mod:`people` app is loaded
+   before any employee is removed, because otherwise, MongoEngine could
+   never know this relationship exists.
+   
+   In Django, be sure to put all apps that have such delete rule declarations in
+   their :file:`models.py` in the :const:`INSTALLED_APPS` tuple.
 
 
 Generic reference fields

--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -193,6 +193,37 @@ as the constructor's argument::
     class ProfilePage(Document):
         content = StringField()
 
+Dealing with deletion of referred documents
+'''''''''''''''''''''''''''''''''''''''''''
+By default, MongoDB doesn't check the integrity of your data, so deleting
+documents that other documents still hold references to will lead to consistency
+issues.  Mongoengine's :class:`ReferenceField` adds some functionality to
+safeguard against these kinds of database integrity problems, providing each
+reference with a delete rule specification.  A delete rule is specified by
+supplying the :attr:`delete_rule` attribute on the :class:`ReferenceField`
+definition, like this::
+
+    class Employee(Document):
+        ...
+        profile_page = ReferenceField('ProfilePage', delete_rule=mongoengine.NULLIFY)
+
+Its value can take any of the following constants:
+
+:const:`mongoengine.DO_NOTHING`
+  This is the default and won't do anything.  Deletes are fast, but may
+  cause database inconsistency or dangling references.
+:const:`mongoengine.DENY`
+  Deletion is denied if there still exist references to the object being
+  deleted.
+:const:`mongoengine.NULLIFY`
+  Any object's fields still referring to the object being deleted are
+  removed (using MongoDB's "unset" operation), effectively nullifying the
+  relationship.
+:const:`mongoengine.CASCADE`
+  Any object containing fields that are refererring to the object being
+  deleted are deleted first.
+
+
 Generic reference fields
 ''''''''''''''''''''''''
 A second kind of reference field also exists,

--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -200,8 +200,8 @@ documents that other documents still hold references to will lead to consistency
 issues.  Mongoengine's :class:`ReferenceField` adds some functionality to
 safeguard against these kinds of database integrity problems, providing each
 reference with a delete rule specification.  A delete rule is specified by
-supplying the :attr:`delete_rule` attribute on the :class:`ReferenceField`
-definition, like this::
+supplying the :attr:`reverse_delete_rule` attributes on the
+:class:`ReferenceField` definition, like this::
 
     class Employee(Document):
         ...

--- a/docs/guide/querying.rst
+++ b/docs/guide/querying.rst
@@ -325,12 +325,6 @@ calling it with keyword arguments::
     # Get top posts
     Post.objects((Q(featured=True) & Q(hits__gte=1000)) | Q(hits__gte=5000))
 
-.. warning::
-   Only use these advanced queries if absolutely necessary as they will execute
-   significantly slower than regular queries. This is because they are not
-   natively supported by MongoDB -- they are compiled to Javascript and sent
-   to the server for execution.
-
 Server-side javascript execution
 ================================
 Javascript functions may be written and sent to the server for execution. The

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -190,6 +190,8 @@ class DocumentMetaclass(type):
         new_class = super_new(cls, name, bases, attrs)
         for field in new_class._fields.values():
             field.owner_document = new_class
+            if hasattr(field, 'delete_rule') and field.delete_rule:
+                field.document_type._meta['delete_rules'][(new_class, field.name)] = field.delete_rule
 
         module = attrs.get('__module__')
 
@@ -258,6 +260,7 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
             'index_drop_dups': False,
             'index_opts': {},
             'queryset_class': QuerySet,
+            'delete_rules': {},
         }
         meta.update(base_meta)
 

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -191,7 +191,8 @@ class DocumentMetaclass(type):
         for field in new_class._fields.values():
             field.owner_document = new_class
             if hasattr(field, 'delete_rule') and field.delete_rule:
-                field.document_type._meta['delete_rules'][(new_class, field.name)] = field.delete_rule
+                field.document_type.register_delete_rule(new_class, field.name,
+                        field.delete_rule)
 
         module = attrs.get('__module__')
 

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -1,5 +1,6 @@
 from queryset import QuerySet, QuerySetManager
 from queryset import DoesNotExist, MultipleObjectsReturned
+from queryset import DO_NOTHING
 
 import sys
 import pymongo
@@ -190,7 +191,7 @@ class DocumentMetaclass(type):
         new_class = super_new(cls, name, bases, attrs)
         for field in new_class._fields.values():
             field.owner_document = new_class
-            if hasattr(field, 'delete_rule') and field.delete_rule:
+            if hasattr(field, 'delete_rule') and field.delete_rule > DO_NOTHING:
                 field.document_type.register_delete_rule(new_class, field.name,
                         field.delete_rule)
 

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -491,6 +491,7 @@ class BaseDocument(object):
 
 if sys.version_info < (2, 5):
     # Prior to Python 2.5, Exception was an old-style class
+    import types
     def subclass_exception(name, parents, unused):
         return types.ClassType(name, parents, {})
 else:

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -492,6 +492,7 @@ class BaseDocument(object):
 if sys.version_info < (2, 5):
     # Prior to Python 2.5, Exception was an old-style class
     def subclass_exception(name, parents, unused):
+        import types
         return types.ClassType(name, parents, {})
 else:
     def subclass_exception(name, parents, module):

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -191,7 +191,7 @@ class DocumentMetaclass(type):
         new_class = super_new(cls, name, bases, attrs)
         for field in new_class._fields.values():
             field.owner_document = new_class
-            delete_rule = getattr(field, 'delete_rule', DO_NOTHING)
+            delete_rule = getattr(field, 'reverse_delete_rule', DO_NOTHING)
             if delete_rule != DO_NOTHING:
                 field.document_type.register_delete_rule(new_class, field.name,
                         delete_rule)

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -191,9 +191,10 @@ class DocumentMetaclass(type):
         new_class = super_new(cls, name, bases, attrs)
         for field in new_class._fields.values():
             field.owner_document = new_class
-            if hasattr(field, 'delete_rule') and field.delete_rule > DO_NOTHING:
+            delete_rule = getattr(field, 'delete_rule', DO_NOTHING)
+            if delete_rule != DO_NOTHING:
                 field.document_type.register_delete_rule(new_class, field.name,
-                        field.delete_rule)
+                        delete_rule)
 
         module = attrs.get('__module__')
 

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -25,6 +25,12 @@ class BaseField(object):
     _index_with_types = True
     _geo_index = False
 
+    # These track each time a Field instance is created. Used to retain order.
+    # The auto_creation_counter is used for fields that MongoEngine implicitly
+    # creates, creation_counter is used for all user-specified fields.
+    creation_counter = 0
+    auto_creation_counter = -1
+
     def __init__(self, db_field=None, name=None, required=False, default=None, 
                  unique=False, unique_with=None, primary_key=False,
                  validation=None, choices=None):
@@ -41,6 +47,13 @@ class BaseField(object):
         self.primary_key = primary_key
         self.validation = validation
         self.choices = choices
+        # Adjust the appropriate creation counter, and save our local copy.
+        if self.db_field == '_id':
+            self.creation_counter = BaseField.auto_creation_counter
+            BaseField.auto_creation_counter -= 1
+        else:
+            self.creation_counter = BaseField.creation_counter
+            BaseField.creation_counter += 1
 
     def __get__(self, instance, owner):
         """Descriptor for retrieving a value from a field in a document. Do 

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -100,9 +100,9 @@ class BaseField(object):
     def _validate(self, value):
         # check choices
         if self.choices is not None:
-            if value not in self.choices:
-                raise ValidationError("Value must be one of %s."
-                    % unicode(self.choices))
+            option_keys = [option_key for option_key, option_value in self.choices]
+            if value not in option_keys:
+                raise ValidationError("Value must be one of %s." % unicode(option_keys))
 
         # check validation argument
         if self.validation is not None:
@@ -254,8 +254,8 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
 
                 # Propagate index options.
                 for key in ('index_background', 'index_drop_dups', 'index_opts'):
-                   if key in base._meta:
-                      base_meta[key] = base._meta[key]
+                    if key in base._meta:
+                        base_meta[key] = base._meta[key]
 
                 id_field = id_field or base._meta.get('id_field')
                 base_indexes += base._meta.get('indexes', [])

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -1,6 +1,6 @@
 from base import (DocumentMetaclass, TopLevelDocumentMetaclass, BaseDocument,
                   ValidationError)
-from queryset import OperationError, DO_NOTHING
+from queryset import OperationError
 from connection import _get_db
 
 import pymongo
@@ -105,9 +105,6 @@ class Document(BaseDocument):
         """This method registers the delete rules to apply when removing this
         object.
         """
-        if rule == DO_NOTHING:
-            return
-
         cls._meta['delete_rules'][(document_cls, field_name)] = rule
 
 

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -1,20 +1,13 @@
 from base import (DocumentMetaclass, TopLevelDocumentMetaclass, BaseDocument,
                   ValidationError)
-from queryset import OperationError
+from queryset import OperationError, DO_NOTHING
 from connection import _get_db
 
 import pymongo
 
 
-__all__ = ['Document', 'EmbeddedDocument', 'ValidationError', 'OperationError',
-        'DO_NOTHING', 'NULLIFY', 'CASCADE', 'DENY']
+__all__ = ['Document', 'EmbeddedDocument', 'ValidationError', 'OperationError']
 
-
-# Delete rules
-DO_NOTHING = 0
-NULLIFY = 1
-CASCADE = 2
-DENY = 3
 
 class EmbeddedDocument(BaseDocument):
     """A :class:`~mongoengine.Document` that isn't stored in its own
@@ -110,7 +103,7 @@ class Document(BaseDocument):
     @classmethod
     def register_delete_rule(cls, document_cls, field_name, rule):
         """This method registers the delete rules to apply when removing this
-        object.  This could go into the Document class.
+        object.
         """
         if rule == DO_NOTHING:
             return

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -105,6 +105,19 @@ class Document(BaseDocument):
 
             if rule == CASCADE:
                 document_cls.objects(**{field_name: self.id}).delete(safe=safe)
+            elif rule == NULLIFY:
+                # TODO: For now, this makes the nullify test pass, but it would
+                # be nicer to use any of these two atomic versions:
+                #
+                #    document_cls.objects(**{field_name: self.id}).update(**{'unset__%s' % field_name: 1})
+                # or
+                #    document_cls.objects(**{field_name: self.id}).update(**{'set__%s' % field_name: None})
+                #
+                # However, I'm getting ValidationError: 1/None is not a valid ObjectId
+                # Anybody got a clue?
+                for doc in document_cls.objects(**{field_name: self.id}):
+                    doc.reviewer = None
+                    doc.save()
 
         id_field = self._meta['id_field']
         object_id = self._fields[id_field].to_mongo(self[id_field])

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -106,18 +106,7 @@ class Document(BaseDocument):
             if rule == CASCADE:
                 document_cls.objects(**{field_name: self.id}).delete(safe=safe)
             elif rule == NULLIFY:
-                # TODO: For now, this makes the nullify test pass, but it would
-                # be nicer to use any of these two atomic versions:
-                #
-                #    document_cls.objects(**{field_name: self.id}).update(**{'unset__%s' % field_name: 1})
-                # or
-                #    document_cls.objects(**{field_name: self.id}).update(**{'set__%s' % field_name: None})
-                #
-                # However, I'm getting ValidationError: 1/None is not a valid ObjectId
-                # Anybody got a clue?
-                for doc in document_cls.objects(**{field_name: self.id}):
-                    doc.reviewer = None
-                    doc.save()
+                document_cls.objects(**{field_name: self.id}).update(**{'unset__%s' % field_name: 1})
 
         id_field = self._meta['id_field']
         object_id = self._fields[id_field].to_mongo(self[id_field])

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -107,7 +107,6 @@ class Document(BaseDocument):
             if rule == DENY and document_cls.objects(**{field_name: self.id}).count() > 0:
                 msg = u'Could not delete document (at least %s.%s refers to it)' % \
                         (document_cls.__name__, field_name)
-                logging.error(msg)
                 raise OperationError(msg)
 
         for rule_entry in self._meta['delete_rules']:

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -99,26 +99,6 @@ class Document(BaseDocument):
 
         :param safe: check if the operation succeeded before returning
         """
-        # Check for DENY rules before actually deleting/nullifying any other
-        # references
-        for rule_entry in self._meta['delete_rules']:
-            document_cls, field_name = rule_entry
-            rule = self._meta['delete_rules'][rule_entry]
-            if rule == DENY and document_cls.objects(**{field_name: self.id}).count() > 0:
-                msg = u'Could not delete document (at least %s.%s refers to it)' % \
-                        (document_cls.__name__, field_name)
-                raise OperationError(msg)
-
-        for rule_entry in self._meta['delete_rules']:
-            document_cls, field_name = rule_entry
-            rule = self._meta['delete_rules'][rule_entry]
-
-            if rule == CASCADE:
-                document_cls.objects(**{field_name: self.id}).delete(safe=safe)
-            elif rule == NULLIFY:
-                document_cls.objects(**{field_name:
-                    self.id}).update(**{'unset__%s' % field_name: 1})
-
         id_field = self._meta['id_field']
         object_id = self._fields[id_field].to_mongo(self[id_field])
         try:

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -99,6 +99,17 @@ class Document(BaseDocument):
 
         :param safe: check if the operation succeeded before returning
         """
+        # Check for DENY rules before actually deleting/nullifying any other
+        # references
+        for rule_entry in self._meta['delete_rules']:
+            document_cls, field_name = rule_entry
+            rule = self._meta['delete_rules'][rule_entry]
+            if rule == DENY and document_cls.objects(**{field_name: self.id}).count() > 0:
+                msg = u'Could not delete document (at least %s.%s refers to it)' % \
+                        (document_cls.__name__, field_name)
+                logging.error(msg)
+                raise OperationError(msg)
+
         for rule_entry in self._meta['delete_rules']:
             document_cls, field_name = rule_entry
             rule = self._meta['delete_rules'][rule_entry]
@@ -106,7 +117,8 @@ class Document(BaseDocument):
             if rule == CASCADE:
                 document_cls.objects(**{field_name: self.id}).delete(safe=safe)
             elif rule == NULLIFY:
-                document_cls.objects(**{field_name: self.id}).update(**{'unset__%s' % field_name: 1})
+                document_cls.objects(**{field_name:
+                    self.id}).update(**{'unset__%s' % field_name: 1})
 
         id_field = self._meta['id_field']
         object_id = self._fields[id_field].to_mongo(self[id_field])

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -339,7 +339,7 @@ class ListField(BaseField):
 
         if isinstance(self.field, ReferenceField):
             referenced_type = self.field.document_type
-            # Get value from document instance if available 
+            # Get value from document instance if available
             value_list = instance._data.get(self.name)
             if value_list:
                 deref_list = []
@@ -599,6 +599,7 @@ class GridFSProxy(object):
 
     def __init__(self, grid_id=None):
         self.fs = gridfs.GridFS(_get_db())  # Filesystem instance
+        self.gridout_instance = None        # File instance
         self.newfile = None                 # Used for partial writes
         self.grid_id = grid_id              # Store GridFS id for file
 
@@ -612,13 +613,16 @@ class GridFSProxy(object):
         return self
 
     def get(self, id=None):
-        if id:
-            self.grid_id = id
-        try:
-            return self.fs.get(id or self.grid_id)
-        except:
-            # File has been deleted
-            return None
+        if not id and self.gridout_instance:
+            return self.gridout_instance
+        else:
+            if id:
+                self.grid_id = id
+            try:
+                return self.fs.get(id or self.grid_id)
+            except:
+                # File has been deleted
+                return None
 
     def new_file(self, **kwargs):
         self.newfile = self.fs.new_file(**kwargs)
@@ -643,7 +647,7 @@ class GridFSProxy(object):
         if not self.newfile:
             self.new_file()
             self.grid_id = self.newfile._id
-        self.newfile.writelines(lines) 
+        self.newfile.writelines(lines)
 
     def read(self):
         try:

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -649,9 +649,9 @@ class GridFSProxy(object):
             self.grid_id = self.newfile._id
         self.newfile.writelines(lines)
 
-    def read(self):
+    def read(self, size=-1):
         try:
-            return self.get().read()
+            return self.get().read(size)
         except:
             return None
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -1,4 +1,5 @@
 from base import BaseField, ObjectIdField, ValidationError, get_document
+from queryset import DO_NOTHING
 from document import Document, EmbeddedDocument
 from connection import _get_db
 from operator import itemgetter
@@ -417,7 +418,7 @@ class ReferenceField(BaseField):
     access (lazily).
     """
 
-    def __init__(self, document_type, delete_rule=None, **kwargs):
+    def __init__(self, document_type, delete_rule=DO_NOTHING, **kwargs):
         if not isinstance(document_type, basestring):
             if not issubclass(document_type, (Document, basestring)):
                 raise ValidationError('Argument to ReferenceField constructor '

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -150,6 +150,8 @@ class IntField(BaseField):
         if self.max_value is not None and value > self.max_value:
             raise ValidationError('Integer value is too large')
 
+    def prepare_query_value(self, op, value):
+        return int(value)
 
 class FloatField(BaseField):
     """An floating point number field.
@@ -172,6 +174,9 @@ class FloatField(BaseField):
 
         if self.max_value is not None and value > self.max_value:
             raise ValidationError('Float value is too large')
+
+    def prepare_query_value(self, op, value):
+        return float(value)
 
 class DecimalField(BaseField):
     """A fixed-point decimal number field.
@@ -227,6 +232,40 @@ class DateTimeField(BaseField):
     def validate(self, value):
         assert isinstance(value, datetime.datetime)
 
+    def prepare_query_value(self, op, value):
+        if value is None:
+            return value
+        if isinstance(value, datetime.datetime):
+            return value
+        if isinstance(value, datetime.date):
+            return datetime.datetime(value.year, value.month, value.day)
+
+        # Attempt to parse a datetime:
+        #value = smart_str(value)
+        # split usecs, because they are not recognized by strptime.
+        if '.' in value:
+            try:
+                value, usecs = value.split('.')
+                usecs = int(usecs)
+            except ValueError:
+                return None
+        else:
+            usecs = 0
+        kwargs = {'microsecond': usecs}
+        try: # Seconds are optional, so try converting seconds first.
+            return datetime.datetime(*time.strptime(value, '%Y-%m-%d %H:%M:%S')[:6],
+                                     **kwargs)
+
+        except ValueError:
+            try: # Try without seconds.
+                return datetime.datetime(*time.strptime(value, '%Y-%m-%d %H:%M')[:5],
+                                         **kwargs)
+            except ValueError: # Try without hour/minutes/seconds.
+                try:
+                    return datetime.datetime(*time.strptime(value, '%Y-%m-%d')[:3],
+                                             **kwargs)
+                except ValueError:
+                    return None
 
 class EmbeddedDocumentField(BaseField):
     """An embedded document field. Only valid values are subclasses of

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -12,7 +12,6 @@ import datetime
 import decimal
 import gridfs
 import warnings
-import types
 
 
 __all__ = ['StringField', 'IntField', 'FloatField', 'BooleanField',

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -418,13 +418,13 @@ class ReferenceField(BaseField):
     access (lazily).
     """
 
-    def __init__(self, document_type, delete_rule=DO_NOTHING, **kwargs):
+    def __init__(self, document_type, reverse_delete_rule=DO_NOTHING, **kwargs):
         if not isinstance(document_type, basestring):
             if not issubclass(document_type, (Document, basestring)):
                 raise ValidationError('Argument to ReferenceField constructor '
                                       'must be a document class or a string')
         self.document_type_obj = document_type
-        self.delete_rule = delete_rule
+        self.reverse_delete_rule = reverse_delete_rule
         super(ReferenceField, self).__init__(**kwargs)
 
     @property

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -417,12 +417,13 @@ class ReferenceField(BaseField):
     access (lazily).
     """
 
-    def __init__(self, document_type, **kwargs):
+    def __init__(self, document_type, delete_rule=None, **kwargs):
         if not isinstance(document_type, basestring):
             if not issubclass(document_type, (Document, basestring)):
                 raise ValidationError('Argument to ReferenceField constructor '
                                       'must be a document class or a string')
         self.document_type_obj = document_type
+        self.delete_rule = delete_rule
         super(ReferenceField, self).__init__(**kwargs)
 
     @property

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -8,7 +8,7 @@ import pymongo
 import pymongo.dbref
 import pymongo.son
 import pymongo.binary
-import datetime
+import datetime, time
 import decimal
 import gridfs
 import warnings

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -907,7 +907,9 @@ class QuerySet(object):
             if rule == CASCADE:
                 document_cls.objects(**{field_name + '__in': self}).delete(safe=safe)
             elif rule == NULLIFY:
-                document_cls.objects(**{field_name + '__in': self}).update(**{'unset__%s' % field_name: 1})
+                document_cls.objects(**{field_name + '__in': self}).update(
+                        safe_update=safe,
+                        **{'unset__%s' % field_name: 1})
 
         self._collection.remove(self._query, safe=safe)
 

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -431,7 +431,9 @@ class QuerySet(object):
                 self._cursor_obj.where(self._where_clause)
 
             # apply default ordering
-            if self._document._meta['ordering']:
+            if self._ordering:
+                self._cursor_obj.sort(self._ordering)
+            elif self._document._meta['ordering']:
                 self.order_by(*self._document._meta['ordering'])
 
             if self._limit is not None:

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -434,6 +434,12 @@ class QuerySet(object):
             if self._document._meta['ordering']:
                 self.order_by(*self._document._meta['ordering'])
 
+            if self._limit is not None:
+                self._cursor_obj.limit(self._limit)
+
+            if self._skip is not None:
+                self._cursor_obj.skip(self._skip)
+
         return self._cursor_obj
 
     @classmethod

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -78,7 +78,7 @@ class SimplificationVisitor(QNodeVisitor):
             # to a single field
             intersection = ops.intersection(query_ops)
             if intersection:
-                msg = 'Duplicate query contitions: '
+                msg = 'Duplicate query conditions: '
                 raise InvalidQueryError(msg + ', '.join(intersection))
 
             query_ops.update(ops)
@@ -179,7 +179,7 @@ class QueryCompilerVisitor(QNodeVisitor):
                     # once to a single field
                     intersection = current_ops.intersection(new_ops)
                     if intersection:
-                        msg = 'Duplicate query contitions: '
+                        msg = 'Duplicate query conditions: '
                         raise InvalidQueryError(msg + ', '.join(intersection))
 
                     # Right! We've got two non-overlapping dicts of operations!

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -812,11 +812,7 @@ class QuerySet(object):
         """
         self._loaded_fields = []
         for field in fields:
-            if '.' in field:
-                raise InvalidQueryError('Subfields cannot be used as '
-                                        'arguments to QuerySet.only')
-            # Translate field name
-            field = QuerySet._lookup_field(self._document, field)[-1].db_field
+            field = ".".join(f.db_field for f in QuerySet._lookup_field(self._document, field.split('.')))
             self._loaded_fields.append(field)
 
         # _cls is needed for polymorphism

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -10,10 +10,17 @@ import copy
 import itertools
 
 __all__ = ['queryset_manager', 'Q', 'InvalidQueryError',
-           'InvalidCollectionError']
+           'InvalidCollectionError', 'DO_NOTHING', 'NULLIFY', 'CASCADE', 'DENY']
+
 
 # The maximum number of items to display in a QuerySet.__repr__
 REPR_OUTPUT_SIZE = 20
+
+# Delete rules
+DO_NOTHING = 0
+NULLIFY = 1
+CASCADE = 2
+DENY = 3
 
 
 class DoesNotExist(Exception):
@@ -882,8 +889,6 @@ class QuerySet(object):
 
         :param safe: check if the operation succeeded before returning
         """
-        from document import CASCADE, DENY, NULLIFY
-
         doc = self._document
 
         # Check for DENY rules before actually deleting/nullifying any other

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -917,8 +917,7 @@ class QuerySet(object):
 
                 # Convert value to proper value
                 field = fields[-1]
-                if op in (None, 'set', 'unset', 'pop', 'push', 'pull',
-                          'addToSet'):
+                if op in (None, 'set', 'push', 'pull', 'addToSet'):
                     value = field.prepare_query_value(op, value)
                 elif op in ('pushAll', 'pullAll'):
                     value = [field.prepare_query_value(op, v) for v in value]

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -867,11 +867,26 @@ class QuerySet(object):
 
 
     def exclude(self, *fields):
+        """Opposite to .only(), exclude some document's fields. ::
+
+            post = BlogPost.objects(...).exclude("comments")
+
+        :param fields: fields to exclude
+        """
         fields = self._fields_to_dbfields(fields)
         self._loaded_fields += QueryFieldList(fields, direction=QueryFieldList.EXCLUDE)
         return self
 
+    def all_fields(self):
+        """Include all fields. Reset all previously calls of .only() and .exclude(). ::
+
+            post = BlogPost.objects(...).exclude("comments").only("title").all_fields()
+        """
+        self._loaded_fields = QueryFieldList(always_include=self._loaded_fields.always_include)
+        return self
+
     def _fields_to_dbfields(self, fields):
+        """Translate fields paths to its db equivalents"""
         ret = []
         for field in fields:
             field = ".".join(f.db_field for f in QuerySet._lookup_field(self._document, field.split('.')))

--- a/tests/document.py
+++ b/tests/document.py
@@ -624,6 +624,31 @@ class DocumentTest(unittest.TestCase):
 
         BlogPost.drop_collection()
 
+
+    def test_cascade_delete(self):
+        """Ensure that a referenced document is also deleted upon deletion.
+        """
+
+        class BlogPost(Document):
+            meta = {'collection': 'blogpost_1'}
+            content = StringField()
+            author = ReferenceField(self.Person, delete_rule=CASCADE)
+
+        self.Person.drop_collection()
+        BlogPost.drop_collection()
+
+        author = self.Person(name='Test User')
+        author.save()
+
+        post = BlogPost(content = 'Watched some TV')
+        post.author = author
+        post.save()
+
+        # Delete the Person, which should lead to deletion of the BlogPost, too
+        author.delete()
+        self.assertEqual(len(BlogPost.objects), 0)
+
+
     def tearDown(self):
         self.Person.drop_collection()
 

--- a/tests/document.py
+++ b/tests/document.py
@@ -502,7 +502,7 @@ class DocumentTest(unittest.TestCase):
         try:
             recipient.save(validate=False)
         except ValidationError:
-            fail()
+            self.fail()
 
     def test_delete(self):
         """Ensure that document may be deleted using the delete method.

--- a/tests/document.py
+++ b/tests/document.py
@@ -625,14 +625,14 @@ class DocumentTest(unittest.TestCase):
         BlogPost.drop_collection()
 
 
-    def test_delete_rule_cascade_and_nullify(self):
+    def test_reverse_delete_rule_cascade_and_nullify(self):
         """Ensure that a referenced document is also deleted upon deletion.
         """
 
         class BlogPost(Document):
             content = StringField()
-            author = ReferenceField(self.Person, delete_rule=CASCADE)
-            reviewer = ReferenceField(self.Person, delete_rule=NULLIFY)
+            author = ReferenceField(self.Person, reverse_delete_rule=CASCADE)
+            reviewer = ReferenceField(self.Person, reverse_delete_rule=NULLIFY)
 
         self.Person.drop_collection()
         BlogPost.drop_collection()
@@ -656,18 +656,18 @@ class DocumentTest(unittest.TestCase):
         author.delete()
         self.assertEqual(len(BlogPost.objects), 0)
 
-    def test_delete_rule_cascade_recurs(self):
+    def test_reverse_delete_rule_cascade_recurs(self):
         """Ensure that a chain of documents is also deleted upon cascaded
         deletion.
         """
 
         class BlogPost(Document):
             content = StringField()
-            author = ReferenceField(self.Person, delete_rule=CASCADE)
+            author = ReferenceField(self.Person, reverse_delete_rule=CASCADE)
 
         class Comment(Document):
             text = StringField()
-            post = ReferenceField(BlogPost, delete_rule=CASCADE)
+            post = ReferenceField(BlogPost, reverse_delete_rule=CASCADE)
 
 
         author = self.Person(name='Test User')
@@ -690,14 +690,14 @@ class DocumentTest(unittest.TestCase):
         BlogPost.drop_collection()
         Comment.drop_collection()
 
-    def test_delete_rule_deny(self):
+    def test_reverse_delete_rule_deny(self):
         """Ensure that a document cannot be referenced if there are still
         documents referring to it.
         """
 
         class BlogPost(Document):
             content = StringField()
-            author = ReferenceField(self.Person, delete_rule=DENY)
+            author = ReferenceField(self.Person, reverse_delete_rule=DENY)
 
         self.Person.drop_collection()
         BlogPost.drop_collection()

--- a/tests/document.py
+++ b/tests/document.py
@@ -630,7 +630,6 @@ class DocumentTest(unittest.TestCase):
         """
 
         class BlogPost(Document):
-            meta = {'collection': 'blogpost_1'}
             content = StringField()
             author = ReferenceField(self.Person, delete_rule=CASCADE)
             reviewer = ReferenceField(self.Person, delete_rule=NULLIFY)

--- a/tests/document.py
+++ b/tests/document.py
@@ -657,6 +657,18 @@ class DocumentTest(unittest.TestCase):
         author.delete()
         self.assertEqual(len(BlogPost.objects), 0)
 
+    def test_delete_rule_cascade_recurs(self):
+        """Ensure that a recursive chain of documents is also deleted upon
+        cascaded deletion.
+        """
+        self.fail()
+
+    def test_delete_rule_deny(self):
+        """Ensure that a document cannot be referenced if there are still
+        documents referring to it.
+        """
+        self.fail()
+
 
     def tearDown(self):
         self.Person.drop_collection()

--- a/tests/document.py
+++ b/tests/document.py
@@ -658,8 +658,8 @@ class DocumentTest(unittest.TestCase):
         self.assertEqual(len(BlogPost.objects), 0)
 
     def test_delete_rule_cascade_recurs(self):
-        """Ensure that a recursive chain of documents is also deleted upon
-        cascaded deletion.
+        """Ensure that a chain of documents is also deleted upon cascaded
+        deletion.
         """
         self.fail()
 

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -523,29 +523,29 @@ class FieldTest(unittest.TestCase):
         Link.drop_collection()
         Post.drop_collection()
         Bookmark.drop_collection()
-    
+
         link_1 = Link(title="Pitchfork")
         link_1.save()
-    
+
         post_1 = Post(title="Behind the Scenes of the Pavement Reunion")
         post_1.save()
-        
+
         bm = Bookmark(bookmark_object=post_1)
         bm.save()
-        
+
         bm = Bookmark.objects(bookmark_object=post_1).first()
-        
+
         self.assertEqual(bm.bookmark_object, post_1)
         self.assertTrue(isinstance(bm.bookmark_object, Post))
-        
+
         bm.bookmark_object = link_1
         bm.save()
-        
+
         bm = Bookmark.objects(bookmark_object=link_1).first()
-        
+
         self.assertEqual(bm.bookmark_object, link_1)
         self.assertTrue(isinstance(bm.bookmark_object, Link))
-    
+
         Link.drop_collection()
         Post.drop_collection()
         Bookmark.drop_collection()
@@ -555,23 +555,23 @@ class FieldTest(unittest.TestCase):
         """
         class Link(Document):
             title = StringField()
-    
+
         class Post(Document):
             title = StringField()
-    
+
         class User(Document):
             bookmarks = ListField(GenericReferenceField())
-    
+
         Link.drop_collection()
         Post.drop_collection()
         User.drop_collection()
-    
+
         link_1 = Link(title="Pitchfork")
         link_1.save()
-    
+
         post_1 = Post(title="Behind the Scenes of the Pavement Reunion")
         post_1.save()
-    
+
         user = User(bookmarks=[post_1, link_1])
         user.save()
         

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -644,7 +644,8 @@ class FieldTest(unittest.TestCase):
         """Ensure that value is in a container of allowed values.
         """
         class Shirt(Document):
-            size = StringField(max_length=3, choices=('S','M','L','XL','XXL'))
+            size = StringField(max_length=3, choices=(('S', 'Small'), ('M', 'Medium'), ('L', 'Large'),
+                                                      ('XL', 'Extra Large'), ('XXL', 'Extra Extra Large')))
 
         Shirt.drop_collection()
 

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -1377,6 +1377,23 @@ class QuerySetTest(unittest.TestCase):
 
         Post.drop_collection()
 
+    def test_call_after_limits_set(self):
+        """Ensure that re-filtering after slicing works
+        """
+        class Post(Document):
+            title = StringField()
+
+        Post.drop_collection()
+
+        post1 = Post(title="Post 1")
+        post1.save()
+        post2 = Post(title="Post 2")
+        post2.save()
+
+        posts = Post.objects.all()[0:1]
+        self.assertEqual(len(list(posts())), 1)
+
+        Post.drop_collection()
 
 class QTest(unittest.TestCase):
 

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -778,6 +778,11 @@ class QuerySetTest(unittest.TestCase):
         BlogPost.objects.update_one(add_to_set__tags='unique')
         post.reload()
         self.assertEqual(post.tags.count('unique'), 1)
+
+        self.assertNotEqual(post.hits, None)
+        BlogPost.objects.update_one(unset__hits=1)
+        post.reload()
+        self.assertEqual(post.hits, None)
         
         BlogPost.drop_collection()
 

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -734,12 +734,12 @@ class QuerySetTest(unittest.TestCase):
         self.Person.objects.delete()
         self.assertEqual(len(self.Person.objects), 0)
 
-    def test_delete_rule_cascade(self):
+    def test_reverse_delete_rule_cascade(self):
         """Ensure cascading deletion of referring documents from the database.
         """
         class BlogPost(Document):
             content = StringField()
-            author = ReferenceField(self.Person, delete_rule=CASCADE)
+            author = ReferenceField(self.Person, reverse_delete_rule=CASCADE)
         BlogPost.drop_collection()
 
         me = self.Person(name='Test User')
@@ -755,7 +755,7 @@ class QuerySetTest(unittest.TestCase):
         self.Person.objects(name='Test User').delete()
         self.assertEqual(1, BlogPost.objects.count())
 
-    def test_delete_rule_nullify(self):
+    def test_reverse_delete_rule_nullify(self):
         """Ensure nullification of references to deleted documents.
         """
         class Category(Document):
@@ -763,7 +763,7 @@ class QuerySetTest(unittest.TestCase):
 
         class BlogPost(Document):
             content = StringField()
-            category = ReferenceField(Category, delete_rule=NULLIFY)
+            category = ReferenceField(Category, reverse_delete_rule=NULLIFY)
 
         BlogPost.drop_collection()
         Category.drop_collection()
@@ -780,13 +780,13 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(1, BlogPost.objects.count())
         self.assertEqual(None, BlogPost.objects.first().category)
 
-    def test_delete_rule_deny(self):
+    def test_reverse_delete_rule_deny(self):
         """Ensure deletion gets denied on documents that still have references
         to them.
         """
         class BlogPost(Document):
             content = StringField()
-            author = ReferenceField(self.Person, delete_rule=DENY)
+            author = ReferenceField(self.Person, reverse_delete_rule=DENY)
 
         BlogPost.drop_collection()
         self.Person.drop_collection()

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -351,8 +351,6 @@ class QuerySetTest(unittest.TestCase):
     def test_filter_chaining(self):
         """Ensure filters can be chained together.
         """
-        from datetime import datetime
-
         class BlogPost(Document):
             title = StringField()
             is_published = BooleanField()

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -734,6 +734,21 @@ class QuerySetTest(unittest.TestCase):
         self.Person.objects.delete()
         self.assertEqual(len(self.Person.objects), 0)
 
+    def test_delete_rule_cascade(self):
+        """Ensure cascading deletion of referring documents from the database.
+        """
+        self.fail()
+
+    def test_delete_rule_nullify(self):
+        """Ensure nullification of references to deleted documents.
+        """
+        self.fail()
+
+    def test_delete_rule_deny(self):
+        """Ensure deletion gets denied on documents that still have references to them.
+        """
+        self.fail()
+
     def test_update(self):
         """Ensure that atomic updates work properly.
         """

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -572,6 +572,29 @@ class QuerySetTest(unittest.TestCase):
 
         Email.drop_collection()
 
+    def test_all_fields(self):
+
+        class Email(Document):
+            sender = StringField()
+            to = StringField()
+            subject = StringField()
+            body = StringField()
+            content_type = StringField()
+
+        Email.drop_collection()
+
+        email = Email(sender='me', to='you', subject='From Russia with Love', body='Hello!', content_type='text/plain')
+        email.save()
+
+        obj = Email.objects.exclude('content_type', 'body').only('to', 'body').all_fields().get()
+        self.assertEqual(obj.sender, 'me')
+        self.assertEqual(obj.to, 'you')
+        self.assertEqual(obj.subject, 'From Russia with Love')
+        self.assertEqual(obj.body, 'Hello!')
+        self.assertEqual(obj.content_type, 'text/plain')
+
+        Email.drop_collection()
+
     def test_find_embedded(self):
         """Ensure that an embedded document is properly returned from a query.
         """

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -1462,6 +1462,27 @@ class QuerySetTest(unittest.TestCase):
 
         Number.drop_collection()
 
+    def test_unset_reference(self):
+        class Comment(Document):
+            text = StringField()
+
+        class Post(Document):
+            comment = ReferenceField(Comment)
+
+        Comment.drop_collection()
+        Post.drop_collection()
+
+        comment = Comment.objects.create(text='test')
+        post = Post.objects.create(comment=comment)
+
+        self.assertEqual(post.comment, comment)
+        Post.objects.update(unset__comment=1)
+        post.reload()
+        self.assertEqual(post.comment, None)
+
+        Comment.drop_collection()
+        Post.drop_collection()
+
 
 class QTest(unittest.TestCase):
 

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -1395,6 +1395,24 @@ class QuerySetTest(unittest.TestCase):
 
         Post.drop_collection()
 
+    def test_order_then_filter(self):
+        """Ensure that ordering still works after filtering.
+        """
+        class Number(Document):
+            n = IntField()
+
+        Number.drop_collection()
+
+        n2 = Number.objects.create(n=2)
+        n1 = Number.objects.create(n=1)
+
+        self.assertEqual(list(Number.objects), [n2, n1])
+        self.assertEqual(list(Number.objects.order_by('n')), [n1, n2])
+        self.assertEqual(list(Number.objects.order_by('n').filter()), [n1, n2])
+
+        Number.drop_collection()
+
+
 class QTest(unittest.TestCase):
 
     def test_empty_q(self):

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -737,7 +737,20 @@ class QuerySetTest(unittest.TestCase):
     def test_delete_rule_cascade(self):
         """Ensure cascading deletion of referring documents from the database.
         """
-        self.fail()
+        class BlogPost(Document):
+            content = StringField()
+            author = ReferenceField(self.Person, delete_rule=CASCADE)
+        BlogPost.drop_collection()
+
+        me = self.Person(name='Test User')
+        me.save()
+
+        post = BlogPost(content='Watching TV', author=me)
+        post.save()
+
+        self.assertEqual(1, BlogPost.objects.count())
+        self.Person.objects.delete()
+        self.assertEqual(0, BlogPost.objects.count())
 
     def test_delete_rule_nullify(self):
         """Ensure nullification of references to deleted documents.

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -744,13 +744,16 @@ class QuerySetTest(unittest.TestCase):
 
         me = self.Person(name='Test User')
         me.save()
+        someoneelse = self.Person(name='Some-one Else')
+        someoneelse.save()
 
-        post = BlogPost(content='Watching TV', author=me)
-        post.save()
+        BlogPost(content='Watching TV', author=me).save()
+        BlogPost(content='Chilling out', author=me).save()
+        BlogPost(content='Pro Testing', author=someoneelse).save()
 
+        self.assertEqual(3, BlogPost.objects.count())
+        self.Person.objects(name='Test User').delete()
         self.assertEqual(1, BlogPost.objects.count())
-        self.Person.objects.delete()
-        self.assertEqual(0, BlogPost.objects.count())
 
     def test_delete_rule_nullify(self):
         """Ensure nullification of references to deleted documents.


### PR DESCRIPTION
Hello,
First of all thanks for developing mongoengine. I'm using it for a project and I found a couple of issue with the GridFS field.
1. Every time you read() a file you create a new object using get(). This caused multiple reads() of the same object to return the same bytes instead of a sequence of bytes. Now I cache the file object and return the cached version of it, therefore everything works as promised. If a new file id is requested a new object is created. 

Maybe you missed this bug in the first place, because it occurs on large files only, where one read() does not return the whole file.
1. I changed read to support number of bytes to read

Please merge these changes to your branch since without them reading objects does not work properly.

thanks!
