### PR TITLE
Additional file-like behavior for FileField

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -620,7 +620,7 @@ class GridFSProxy(object):
         # Delete file from GridFS, FileField still remains
         self.fs.delete(self.grid_id)
         self.grid_id = None
-        self.grid_out = None
+        self.gridout = None
 
     def replace(self, file, **kwargs):
         self.delete()

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -561,6 +561,7 @@ class GridFSProxy(object):
         self.fs = gridfs.GridFS(_get_db())  # Filesystem instance
         self.newfile = None                 # Used for partial writes
         self.grid_id = grid_id              # Store GridFS id for file
+        self.gridout = None
 
     def __getattr__(self, name):
         obj = self.get()
@@ -574,8 +575,12 @@ class GridFSProxy(object):
     def get(self, id=None):
         if id:
             self.grid_id = id
+        if self.grid_id is None:
+            return None
         try:
-            return self.fs.get(id or self.grid_id)
+            if self.gridout is None:
+                self.gridout = self.fs.get(self.grid_id)
+            return self.gridout
         except:
             # File has been deleted
             return None
@@ -605,9 +610,9 @@ class GridFSProxy(object):
             self.grid_id = self.newfile._id
         self.newfile.writelines(lines) 
 
-    def read(self):
+    def read(self, size=-1):
         try:
-            return self.get().read()
+            return self.get().read(size)
         except:
             return None
 
@@ -615,6 +620,7 @@ class GridFSProxy(object):
         # Delete file from GridFS, FileField still remains
         self.fs.delete(self.grid_id)
         self.grid_id = None
+        self.grid_out = None
 
     def replace(self, file, **kwargs):
         self.delete()

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -700,6 +700,12 @@ class FieldTest(unittest.TestCase):
         self.assertTrue(streamfile == result)
         self.assertEquals(result.file.read(), text + more_text)
         self.assertEquals(result.file.content_type, content_type)
+        result.file.seek(0)
+        self.assertEquals(result.file.tell(), 0)
+        self.assertEquals(result.file.read(len(text)), text)
+        self.assertEquals(result.file.tell(), len(text))
+        self.assertEquals(result.file.read(len(more_text)), more_text)
+        self.assertEquals(result.file.tell(), len(text + more_text))
         result.file.delete()
 
         # Ensure deleted file returns None


### PR DESCRIPTION
First big thank you for all the hard work and creativity that's gone            into MongoEngine, it's a pleasure to use.

This pull request adds expected _file-like object behavior_ to the
_FileField_:
1. Adds an optional _size_ argument to the _GridFSProxy.read_ method
   to implement more fully file-like behavior. This enables clients to
   read a file in chunks e.g. _PIL.Image.open()_ requires this
   behavior.
2. Fixes the _GridFSProxy_ so that _seek_ and _tell_ methods work when
   reading files. It does this by caching the _GridOut_ object. The
   current implementation instantiates a new _GridOut_ object every
   time the _GridFSProxy_ is invoked which effectively resets the
   state of the file pointer.

I've also included tests for the new functionality.

See also http://docs.python.org/library/stdtypes.html#file-objects
