### PR TITLE
Drop gridfs close warning

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -623,9 +623,6 @@ class GridFSProxy(object):
     def close(self):
         if self.newfile:
             self.newfile.close()
-        else:
-            msg = "The close() method is only necessary after calling write()"
-            warnings.warn(msg)
 
 
 class FileField(BaseField):


### PR DESCRIPTION
Please consider dropping the warning message that is emitted when a
gridfs file is closed.

Some software (for example the _FileWrapper_ class in the Python 
_wsgiref_ standard library) test for a _close_ method when reading
file-like objects and execute it if it exists.  This normal behavior
results in spurious and misleading console messages from MongoEngine:

`UserWarning: The close() method is only necessary after calling 
write()`

The warning itself is more of a lint warning for the programmer than a
runtime warning (calling the close method is benign and could never
cause a problem).
