### PR TITLE
Fixed MapReduce to support MongoDB v.1.8

### DIFF
--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -667,7 +667,7 @@ class QuerySet(object):
     def __len__(self):
         return self.count()
 
-    def map_reduce(self, map_f, reduce_f, finalize_f=None, limit=None,
+    def map_reduce(self, map_f, reduce_f, out, finalize_f=None, limit=None,
                    scope=None, keep_temp=False):
         """Perform a map/reduce query using the current query spec
         and ordering. While ``map_reduce`` respects ``QuerySet`` chaining,
@@ -731,6 +731,8 @@ class QuerySet(object):
 
         if limit:
             mr_args['limit'] = limit
+            
+        mr_args['out'] = out
 
         results = self._collection.map_reduce(map_f, reduce_f, **mr_args)
         results = results.find()

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -681,6 +681,7 @@ class QuerySet(object):
         :param map_f: map function, as :class:`~pymongo.code.Code` or string
         :param reduce_f: reduce function, as
                          :class:`~pymongo.code.Code` or string
+        :param out: name of the collection to hold the map_reduce results data 
         :param finalize_f: finalize function, an optional function that
                            performs any post-reduction processing.
         :param scope: values to insert into map/reduce global scope. Optional.

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -800,9 +800,9 @@ class QuerySetTest(unittest.TestCase):
                 return total;
             }
         """
-
+        out = 'mapreducetempdata'
         # run a map/reduce operation spanning all posts
-        results = BlogPost.objects.map_reduce(map_f, reduce_f)
+        results = BlogPost.objects.map_reduce(map_f, reduce_f, out)
         results = list(results)
         self.assertEqual(len(results), 4)
 
@@ -850,8 +850,8 @@ class QuerySetTest(unittest.TestCase):
                 return total;
             }
         """
-        
-        results = BlogPost.objects.map_reduce(map_f, reduce_f)
+        out = 'mapreducetempdata'
+        results = BlogPost.objects.map_reduce(map_f, reduce_f, out)
         results = list(results)
         
         self.assertEqual(results[0].object, post1)
@@ -960,8 +960,10 @@ class QuerySetTest(unittest.TestCase):
         # to "-value", which orders the "weight" value returned from
         # "finalize_f" in descending order.
         results = Link.objects.order_by("-value")
+        out = 'mapreducetempdata'
         results = results.map_reduce(map_f,
                                      reduce_f,
+                                     out,
                                      finalize_f=finalize_f,
                                      scope=scope)
         results = list(results)


### PR DESCRIPTION
I have fixed the QuerySet.map_reduce() function by adding out argument to support the new MongoDB 1.8 MapReduce functionality,
It requires pymongo v.1.10+
