### PR TITLE
tiny documentation fix

### DIFF
--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -134,8 +134,8 @@ document class as the first argument::
     class Page(Document):
         comments = ListField(EmbeddedDocumentField(Comment))
 
-    comment1 = Comment('Good work!')
-    comment2 = Comment('Nice article!')
+    comment1 = Comment(content='Good work!')
+    comment2 = Comment(content='Nice article!')
     page = Page(comments=[comment1, comment2])
 
 Dictionary Fields


### PR DESCRIPTION
I found a bug in the documentation, here: http://mongoengine.org/docs/v0.4/guide/defining-documents.html#embedded-documents

`comment1 = Comment('Good work!')` should be `comment1 = Comment(content='Good work!')`, and so on.
