### PR TITLE
Django Test

### DIFF
--- a/mongoengine/django/tests.py
+++ b/mongoengine/django/tests.py
@@ -25,7 +25,7 @@ class MongoTestCase(TestCase):
         Overwrites this Django TestCase function to run smoothly with MongoDB.
         Without this, everytime Django tries to create a normal database using its database dict
         '''
-        if not settings.DATABASES or settings.DATABASE_ENGINE:
+        if not (settings.DATABASES or settings.DATABASE_ENGINE):
             pass
         else:
             super(TestCase, self)._fixture_setup(self)

--- a/mongoengine/django/tests.py
+++ b/mongoengine/django/tests.py
@@ -19,3 +19,11 @@ class MongoTestCase(TestCase):
             if collection == 'system.indexes':
                 continue
             self.db.drop_collection(collection)
+
+    def _fixture_setup(self):
+        '''
+        Overwrites this Django TestCase function to run smoothly with MongoDB.
+        Without this, Django tries to create a normal database using its database dict
+        '''
+        pass
+

--- a/mongoengine/django/tests.py
+++ b/mongoengine/django/tests.py
@@ -23,7 +23,9 @@ class MongoTestCase(TestCase):
     def _fixture_setup(self):
         '''
         Overwrites this Django TestCase function to run smoothly with MongoDB.
-        Without this, Django tries to create a normal database using its database dict
+        Without this, everytime Django tries to create a normal database using its database dict
         '''
-        pass
-
+        if not settings.DATABASES or settings.DATABASE_ENGINE:
+            pass
+        else:
+            super(TestCase, self)._fixture_setup(self)


### PR DESCRIPTION
Hy everyone. I'm having this problem running tests of my Django's project using mongoengine. The problem is that the Django TestCase has a method called _fixture_setup (called in its _pre_setup routine) which is responsible for load all the data at the fixtures files. To do this, it requires the use and creation of a db with has a supported backend in Django (it gets this values from the settings file). So, everytime I run the tests, it raises an exception telling me that I need to specify a database engine. To solve my problem, I overwrited this _fixture_setup function to do nothing and everything ran OK. So that's what this pull request is all about.
