### PR TITLE
Indexes as dictionaries, sparse indexes, optional exclude _types

### DIFF
--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -341,9 +341,10 @@ Indexes
 You can specify indexes on collections to make querying faster. This is done
 by creating a list of index specifications called :attr:`indexes` in the
 :attr:`~mongoengine.Document.meta` dictionary, where an index specification may
-either be a single field name, or a tuple containing multiple field names. A
-direction may be specified on fields by prefixing the field name with a **+**
-or a **-** sign. Note that direction only matters on multi-field indexes. ::
+either be a single field name, a tuple containing multiple field names, or a
+dictionary containing a full index definition. A direction may be specified on
+fields by prefixing the field name with a **+** or a **-** sign. Note that
+direction only matters on multi-field indexes. ::
 
     class Page(Document):
         title = StringField()
@@ -351,6 +352,21 @@ or a **-** sign. Note that direction only matters on multi-field indexes. ::
         meta = {
             'indexes': ['title', ('title', '-rating')]
         }
+
+If a dictionary is passed then the following options are available:
+
+:attr:`fields` (Default: None)
+    The fields to index. Specified in the same format as described above.
+
+:attr:`types` (Default: True)
+    Whether the index should have the :attr:`_types` field added automatically
+    to the start of the index.
+
+:attr:`sparse` (Default: False)
+    Whether the index should be sparse.
+
+:attr:`unique` (Default: False)
+    Whether the index should be sparse.
 
 .. note::
    Geospatial indexes will be automatically created for all 

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -376,9 +376,13 @@ class QuerySet(object):
             construct a multi-field index); keys may be prefixed with a **+**
             or a **-** to determine the index ordering
         """
-        index_list = QuerySet._build_index_spec(self._document, key_or_list)
-        self._collection.ensure_index(index_list, drop_dups=drop_dups,
-            background=background)
+        index_spec = QuerySet._build_index_spec(self._document, key_or_list)
+        self._collection.ensure_index(
+            index_spec['fields'], 
+            drop_dups=drop_dups,
+            background=background,
+            sparse=index_spec.get('sparse', False),
+            unique=index_spec.get('unique', False))
         return self
 
     @classmethod

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -2101,6 +2101,9 @@ class QuerySetTest(unittest.TestCase):
 
 class QTest(unittest.TestCase):
 
+    def setUp(self):
+        connect(db='mongoenginetest')
+
     def test_empty_q(self):
         """Ensure that empty Q objects won't hurt.
         """

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -2099,6 +2099,22 @@ class QuerySetTest(unittest.TestCase):
         Number.drop_collection()
 
 
+    def test_ensure_index(self):
+        """Ensure that manual creation of indexes works.
+        """
+        class Comment(Document):
+            message = StringField()
+
+        Comment.objects.ensure_index('message')
+
+        info = Comment.objects._collection.index_information()
+        info = [(value['key'],
+                 value.get('unique', False),
+                 value.get('sparse', False))
+                for key, value in info.iteritems()]
+        self.assertTrue(([('_types', 1), ('message', 1)], False, False) in info)
+
+
 class QTest(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Add support for indexes to be specified as dictionaries. E.g.

``` python
indexes = [
    {'fields': ['name'], 'sparse': True, 'types': False, 'unique': True}
]
```

Will create a sparse unique index on just the name field (excludes _types).

Defaults if any keys are omitted from the dictionary:
- sparse - False
- unique - False
- types - True

Further, existing behaviour is maintained.
