### PR TITLE
Add GridFSProxy.__nonzero__

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -571,6 +571,9 @@ class GridFSProxy(object):
     def __get__(self, instance, value):
         return self
 
+    def __nonzero__(self):
+        return bool(self.grid_id)
+
     def get(self, id=None):
         if id:
             self.grid_id = id

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -753,6 +753,21 @@ class FieldTest(unittest.TestCase):
 
         TestFile.drop_collection()
 
+    def test_file_boolean(self):
+        """Ensure that a boolean test of a FileField indicates its presence
+        """
+        class TestFile(Document):
+            file = FileField()
+
+        testfile = TestFile()
+        self.assertFalse(bool(testfile.file))
+        testfile.file = 'Hello, World!'
+        testfile.file.content_type = 'text/plain'
+        testfile.save()
+        self.assertTrue(bool(testfile.file))
+
+        TestFile.drop_collection()
+
     def test_geo_indexes(self):
         """Ensure that indexes are created automatically for GeoPointFields.
         """


### PR DESCRIPTION
For documents that do not have a value set for a given field, most field types
return None (or [] in the case of ListField). This makes it easy to test
whether a field has been set using "if doc.field". FileFields, on the other
hand, always return a GridFSProxy. Adding GridFSProxy.**nonzero** which simply
checks for a grid_id allows the same boolean-test pattern for FileFields, as
well.
