### PR TITLE
Add GridFSProxy.__nonzero__

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -723,6 +723,9 @@ class GridFSProxy(object):
     def __get__(self, instance, value):
         return self
 
+    def __nonzero__(self):
+        return bool(self.grid_id)
+
     def get(self, id=None):
         if id:
             self.grid_id = id
@@ -805,7 +808,7 @@ class FileField(BaseField):
         # Check if a file already exists for this model
         grid_file = instance._data.get(self.name)
         self.grid_file = grid_file
-        if self.grid_file:
+        if isinstance(self.grid_file, GridFSProxy):
             if not self.grid_file.key:
                 self.grid_file.key = self.name
                 self.grid_file.instance = instance

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -1300,6 +1300,21 @@ class FieldTest(unittest.TestCase):
 
         TestFile.drop_collection()
 
+    def test_file_boolean(self):
+        """Ensure that a boolean test of a FileField indicates its presence
+        """
+        class TestFile(Document):
+            file = FileField()
+
+        testfile = TestFile()
+        self.assertFalse(bool(testfile.file))
+        testfile.file = 'Hello, World!'
+        testfile.file.content_type = 'text/plain'
+        testfile.save()
+        self.assertTrue(bool(testfile.file))
+
+        TestFile.drop_collection()
+
     def test_geo_indexes(self):
         """Ensure that indexes are created automatically for GeoPointFields.
         """


### PR DESCRIPTION
For documents that do not have a value set for a given field, most field types
return None (or [] in the case of ListField). This makes it easy to test
whether a field has been set using "if doc.field". FileFields, on the other
hand, always return a GridFSProxy. Adding GridFSProxy.**nonzero** which simply
checks for a grid_id allows the same boolean-test pattern for FileFields, as
well.
