### PR TITLE
List field lookup

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -86,6 +86,20 @@ class Document(BaseDocument):
         id_field = self._meta['id_field']
         self[id_field] = self._fields[id_field].to_python(object_id)
 
+    def update(self, safe_update=True, **kwargs):
+        """Perform an atomic update on the fields matched by the query.
+        Accepts the same arguments as :meth:`~mongoengine.QuerySet.update`,
+        except `upsert` (which is always set to `False`). Raises
+        :class:`RuntimeError` if called on an object that has not yet been
+        saved.
+        """
+        if not self.pk:
+            raise RuntimeError('attempt to update a document not yet saved')
+
+        kwargs.pop('upsert', None)
+        kwargs.update(safe_update=safe_update)
+        return self.__class__.objects(pk=self.pk).update(**kwargs)
+
     def delete(self, safe=False):
         """Delete the :class:`~mongoengine.Document` from the database. This
         will only take effect if the document has been previously saved.

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -447,6 +447,11 @@ class QuerySet(object):
         """Lookup a field based on its attribute and return a list containing
         the field's parents and the field.
         """
+        from fields import ListField
+        class ListIndexField(object):
+            def __init__(self, db_field):
+                self.db_field = db_field
+
         if not isinstance(parts, (list, tuple)):
             parts = [parts]
         fields = []
@@ -459,6 +464,12 @@ class QuerySet(object):
                     field_name = document._meta['id_field']
                 field = document._fields[field_name]
             else:
+                if isinstance(field, ListField) and field_name.isdigit():
+                    # insert a fake field into the output,
+                    # with db_field set to field_name
+                    fields.append(ListIndexField(field_name))
+                    # don't update field after doing this
+                    continue
                 # Look up subfield on the previous field
                 field = field.lookup_member(field_name)
                 if field is None:


### PR DESCRIPTION
Allow _lookup_fields to work with ListField and SortedListField

This is necessary so that you can do django-style updates like:

```
Model.objects(pk=...).update(push__array__0="new_value")
```

Also adds an `update()` method to `Document` so that this is identical to the above:

```
m = Model.objects(pk=...).first()
m.update(push__array__0="new_value")
```
