### PR TITLE
allow reload()ing selected fields only

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -216,15 +216,25 @@ class Document(BaseDocument):
         self._data = dereference(self._data, max_depth)
         return self
 
-    def reload(self):
+    def reload(self, only=None):
         """Reloads all attributes from the database.
 
+        :param only: if set to a field name, or a list or tuple
+            of field names, only the named fields are reloaded
+
         .. versionadded:: 0.1.2
+        .. versionchanged:: 0.5 Added *only* argument
         """
         id_field = self._meta['id_field']
-        obj = self.__class__.objects(**{id_field: self[id_field]}).first()
+        obj = self.__class__.objects(**{id_field: self[id_field]})
+        if only and type(only) in (str, unicode, list, tuple):
+            if type(only) in (str, unicode):
+                only = [only]
+            obj = obj.only(*only)
+        obj = obj.first()
         for field in self._fields:
-            setattr(self, field, self._reload(field, obj[field]))
+            if not only or field in only:
+                setattr(self, field, self._reload(field, obj[field]))
         self._changed_fields = []
 
     def _reload(self, key, value):

--- a/tests/document.py
+++ b/tests/document.py
@@ -935,6 +935,39 @@ class DocumentTest(unittest.TestCase):
         self.assertEqual(person.name, "Mr Test User")
         self.assertEqual(person.age, 21)
 
+    def test_reload_with_only(self):
+        """Ensure that selected attributes may be reloaded.
+        """
+        person = self.Person(name="Test User", age=20)
+        person.save()
+
+        person_obj = self.Person.objects.first()
+        person_obj.name = "Mr Test User"
+        person_obj.age = 21
+        person_obj.save()
+
+        self.assertEqual(person.name, "Test User")
+        self.assertEqual(person.age, 20)
+
+        person.reload(only='name')
+        self.assertEqual(person.name, "Mr Test User")
+        # we only reloaded name, so age
+        # will not have been updated
+        self.assertEqual(person.age, 20)
+
+        # ensure that reload(only=...) works with
+        # multiple fields as well
+        person_obj.name = "Mrs Test User"
+        person_obj.save()
+        person.reload(only=['name', 'age'])
+        self.assertEqual(person.name, "Mrs Test User")
+        self.assertEqual(person.age, 21)
+
+        # reload(only=...) with fields that don't exist
+        # for the model raises
+        # FIXME: use a more specific exception
+        self.assertRaises(KeyError, person.reload, only=['not_a_field'])
+
     def test_reload_referencing(self):
         """Ensures reloading updates weakrefs correctly
         """


### PR DESCRIPTION
This is useful if your document is large and you only need to reload a subset of it. Comes with a test.
