### PR TITLE
Dev

### DIFF
--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -1268,6 +1268,9 @@ class QuerySet(object):
 
         .. versionadded:: 0.2
         """
+        if not update:
+            raise OperationError("No update parameters, would remove data")
+
         if pymongo.version < '1.1.1':
             raise OperationError('update() method requires PyMongo 1.1.1+')
 
@@ -1298,6 +1301,9 @@ class QuerySet(object):
 
         .. versionadded:: 0.2
         """
+        if not update:
+            raise OperationError("No update parameters, would remove data")
+
         if not write_options:
             write_options = {}
         update = QuerySet._transform_update(self._document, **update)


### PR DESCRIPTION
Hey,

I was accidentally deleting my documents by passing a dictionary argument to queryset.update(), so I added a check that makes update() and update_one() fail if the keyword parameters are empty. This was pretty mystifying to debug.

Regards,
Leo
