### PR TITLE
Get or 404

### DIFF
--- a/mongoengine/django/shortcuts.py
+++ b/mongoengine/django/shortcuts.py
@@ -1,6 +1,7 @@
 from django.http import Http404
 from mongoengine.queryset import QuerySet
 from mongoengine.base import BaseDocument
+from mongoengine.base import ValidationError
 
 def _get_queryset(cls):
     """Inspired by django.shortcuts.*"""
@@ -25,7 +26,7 @@ def get_document_or_404(cls, *args, **kwargs):
     queryset = _get_queryset(cls)
     try:
         return queryset.get(*args, **kwargs)
-    except queryset._document.DoesNotExist:
+    except (queryset._document.DoesNotExist, ValidationError):
         raise Http404('No %s matches the given query.' % queryset._document._class_name)
 
 def get_list_or_404(cls, *args, **kwargs):

--- a/tests/django_tests.py
+++ b/tests/django_tests.py
@@ -3,7 +3,9 @@
 import unittest
 
 from mongoengine import *
+from mongoengine.django.shortcuts import get_document_or_404
 
+from django.http import Http404
 from django.template import Context, Template
 from django.conf import settings
 settings.configure()
@@ -57,3 +59,11 @@ class QuerySetTest(unittest.TestCase):
 
         # Check double rendering doesn't throw an error
         self.assertEqual(t.render(Context(d)), 'D-10:C-30:')
+
+    def test_get_document_or_404(self):
+        p = self.Person(name="G404")
+        p.save()
+
+        self.assertRaises(Http404, get_document_or_404, self.Person, pk='1234')
+        self.assertEqual(p, get_document_or_404(self.Person, pk=p.pk))
+


### PR DESCRIPTION
Raise a 404 when `get_document_or_404(Model, pk=obj_id_string)` is called with `obj_id_string` which is not a valid `ObjectId` string representation (and test)
