### PR TITLE
Where clause

### DIFF
--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -1398,6 +1398,10 @@ class QuerySet(object):
         return db.eval(code, *fields)
 
     def where(self, where_clause):
+        """Filter ``QuerySet`` results with a ``$where`` clause (a Javascript
+        expression). Performs automatic field name substitution like
+        :meth:`mongoengine.queryset.Queryset.exec_js`.
+        """
         where_clause = self._sub_js_fields(where_clause)
         self._where_clause = where_clause
         return self

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -1397,6 +1397,11 @@ class QuerySet(object):
         db = _get_db()
         return db.eval(code, *fields)
 
+    def where(self, where_clause):
+        where_clause = self._sub_js_fields(where_clause)
+        self._where_clause = where_clause
+        return self
+
     def sum(self, field):
         """Sum over the values of the specified field.
 

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -2502,6 +2502,34 @@ class QuerySetTest(unittest.TestCase):
                 for key, value in info.iteritems()]
         self.assertTrue(([('_types', 1), ('message', 1)], False, False) in info)
 
+    def test_where(self):
+        """Ensure that where clauses work.
+        """
+
+        class IntPair(Document):
+            fielda = IntField()
+            fieldb = IntField()
+
+        IntPair.objects._collection.remove()
+
+        a = IntPair(fielda=1, fieldb=1)
+        b = IntPair(fielda=1, fieldb=2)
+        c = IntPair(fielda=2, fieldb=1)
+        a.save()
+        b.save()
+        c.save()
+
+        query = IntPair.objects.where('this[~fielda] >= this[~fieldb]')
+        self.assertEqual('this["fielda"] >= this["fieldb"]', query._where_clause)
+        results = list(query)
+        self.assertEqual(2, len(results))
+        self.assertTrue(a in results)
+        self.assertTrue(c in results)
+
+        query = IntPair.objects.where('this[~fielda] == this[~fieldb]')
+        results = list(query)
+        self.assertEqual(1, len(results))
+        self.assertTrue(a in results)
 
 class QTest(unittest.TestCase):
 


### PR DESCRIPTION
adds `where()` method to `QuerySet`

right now, the test I've added is failing when I run as `python setup.py test`; if I execute the `tests/queryset.py` directly, the test passes. This seems to be related to the test in `tests/signals.py`, since if I remove that file, the tests pass no matter which way I run. I don't know why this is happening, any thoughts?
