### PR TITLE
GenericEmbeddedDocumentField

### DIFF
--- a/tests/fields.py
+++ b/tests/fields.py
@@ -1488,5 +1488,30 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(c['next'], 10)
 
 
+    def test_generic_embedded_document(self):
+        class Car(EmbeddedDocument):
+            name = StringField()
+
+        class Dish(EmbeddedDocument):
+            food = StringField(required=True)
+            number = IntField()
+
+        class Person(Document):
+            name = StringField()
+            like = GenericEmbeddedDocumentField()
+
+        person = Person(name='Test User')
+        person.like = Car(name='Fiat')
+        person.save()
+
+        person = Person.objects.first()
+        self.assertTrue(isinstance(person.like, Car))
+
+        person.like = Dish(food="arroz", number=15)
+        person.save()
+
+        person = Person.objects.first()
+        self.assertTrue(isinstance(person.like, Dish))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
For this example.

``` python
class Friend(EmbeddedDocument):
     name = StringField()

class Car(EmbeddedDocument):
     year = IntField()


class Person(Document):
      like = GenericEmbeddedDocumentField()

p1 = Person()
p1.like = Friend(name="Wesley")
p1.save()

p2 = Person()
p2.like = Car(year=1992)
p2.save()
```
