### PR TITLE
Dereference fails (allow_inheritance = False)

### DIFF
--- a/tests/document.py
+++ b/tests/document.py
@@ -289,6 +289,31 @@ class DocumentTest(unittest.TestCase):
         Zoo.drop_collection()
         Animal.drop_collection()
 
+    def test_reference_inheritance(self):
+        class Stats(Document):
+            created = DateTimeField(default=datetime.now)
+
+            meta = {'allow_inheritance': False}
+
+        class CompareStats(Document):
+            generated = DateTimeField(default=datetime.now)
+            stats = ListField(ReferenceField(Stats))
+
+        Stats.drop_collection()
+        CompareStats.drop_collection()
+
+        list_stats = []
+
+        for i in xrange(10):
+            s = Stats()
+            s.save()
+            list_stats.append(s)
+
+        cmp_stats = CompareStats(stats=list_stats)
+        cmp_stats.save()
+
+        self.assertEqual(list_stats, CompareStats.objects.first().stats)
+
     def test_inheritance(self):
         """Ensure that document may inherit fields from a superclass document.
         """


### PR DESCRIPTION
for this test case:

``` python
import datetime
from mongoengine import *
connect('teste')

class Stats(Document):
    created = DateTimeField(default=datetime.datetime.now)

    meta = {'allow_inheritance': False}

class CompareStats(Document):
    generated = DateTimeField(default=datetime.datetime.now)
    stats = ListField(ReferenceField(Stats))

Stats.drop_collection()
CompareStats.drop_collection()

list_stats = []
for i in xrange(10):
    s = Stats()
    s.save()
    list_stats.append(s)

cmp_stats = CompareStats(stats=list_stats)
cmp_stats.save()

print CompareStats.objects.first().stats
```

raises the error:

wilson@(none):~/Lethus/social$ python2 teste.py 
Traceback (most recent call last):
  File "teste.py", line 26, in <module>
    print CompareStats.objects.first().stats
  File "/usr/lib/python2.7/site-packages/mongoengine-0.4-py2.7.egg/mongoengine/base.py", line 172, in **get**
    instance._data.get(self.name), max_depth=1, instance=instance, name=self.name, get=True
  File "/usr/lib/python2.7/site-packages/mongoengine-0.4-py2.7.egg/mongoengine/dereference.py", line 36, in __call__
    self.object_map = self._fetch_objects()
  File "/usr/lib/python2.7/site-packages/mongoengine-0.4-py2.7.egg/mongoengine/dereference.py", line 97, in _fetch_objects
    doc = get_document(ref['_cls'])._from_son(ref)
KeyError: '_cls'

After this patch:
Ran 216 tests in 5.235s

OK
