### PR TITLE
check for presence of _geo_indices on field class before referencing

### DIFF
--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -812,7 +812,8 @@ class BaseDocument(object):
                 field_cls = field.document_type
                 if field_cls in inspected_classes:
                     continue
-                geo_indices += field_cls._geo_indices(inspected_classes)
+                if hasattr(field_cls, '_geo_indices'):
+                    geo_indices += field_cls._geo_indices(inspected_classes)
             elif field._geo_index:
                 geo_indices.append(field)
         return geo_indices


### PR DESCRIPTION
We have a custom field that links through to django types... and they don't have _geo_indices :)
