### PR TITLE
Enable chainable QuerySet slice

### DIFF
--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -1031,7 +1031,7 @@ class QuerySet(object):
                 if key.start is not None:
                     key_start = int(key.start)
                     if qs_limit: # use new limit immediately
-                        qs_skip = min(start + int(key.start), qs_limit)
+                        qs_skip = min(start + key_start, qs_limit)
                     else: # None or 0
                         qs_skip = start + key_start
                 qs._cursor_obj = qs._cursor[qs_skip:qs_limit]

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,5 @@ setup(name='mongoengine',
       classifiers=CLASSIFIERS,
       install_requires=['pymongo'],
       test_suite='tests',
-      tests_require=['blinker', 'django==1.3']
+      tests_require=['blinker', 'django>=1.3']
 )


### PR DESCRIPTION
Hi,
This patch tries to make QuerySet slice to be chainable, and thus make a QuerySet to return its clone for slicing instead of changing the querying state of itself in place. Current behavior is similar with PyMongo, but is confusing when it is compared to Django ORM, and IMHO, could be error-prone. Some comparisons here:

```
>>> qs = User.objects
>>> qs
[<User: John, Doe>, <User: x, y>, <User: foo, bar>]

# before the patch
>>> qs[1:][1:] # as PyMongo, only last slice has effect
[<User: x, y>, <User: foo, bar>]
>>> sub_qs = qs[1:]
>>> sub_qs
[<User: x, y>, <User: foo, bar>]
>>> sub_qs[:1]
[<User: John, Doe>]
>>> sub_qs
[<User: John, Doe>]

# with the patch
>>> qs[1:][1:]
[<User: foo, bar>]
>>> sub_qs = qs[1:]
>>> sub_qs
[<User: x, y>, <User: foo, bar>]
>>> sub_qs[:1]
[<User: x, y>]
>>> sub_qs
[<User: x, y>, <User: foo, bar>]

# pending issue
# The PyMongo does not check whether the lookup index is outbound, neither do the MongoEngine. 
# The behavior is strange and may need another fix.
>>> qs[:1][1] 
<User: x, y>
```

Other modifications in the patch are:
- add some tests.
- make clone method of a QuerySet obj to try to clone obj._cursor_obj as well
- simplify QuerySet.__repr__ , which is a side-effect of cloned and chainable QuerySet
- enable test for Django with version > 1.3 (test passed in Django 1.3/1.3.1/Trunk with PyMongo 1.11 and 2.0.1)

I'm not sure whether the current implementation has other considerations. Please let me know if there is any doubt. Thanks =)

B.R.
