### PR TITLE
Add UUIDField

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -13,6 +13,7 @@ import pymongo.binary
 import datetime, time
 import decimal
 import gridfs
+import uuid
 
 
 __all__ = ['StringField', 'IntField', 'FloatField', 'BooleanField',
@@ -21,7 +22,7 @@ __all__ = ['StringField', 'IntField', 'FloatField', 'BooleanField',
            'DecimalField', 'ComplexDateTimeField', 'URLField',
            'GenericReferenceField', 'FileField', 'BinaryField',
            'SortedListField', 'EmailField', 'GeoPointField',
-           'SequenceField', 'GenericEmbeddedDocumentField']
+           'SequenceField', 'UUIDField', 'GenericEmbeddedDocumentField']
 
 RECURSIVE_REFERENCE_CONSTANT = 'self'
 
@@ -978,3 +979,30 @@ class SequenceField(IntField):
         if value is None:
             value = self.generate_new_value()
         return value
+
+
+class UUIDField(BaseField):
+    """A UUID field.
+
+    .. versionadded:: 0.6
+    """
+
+    def __init__(self, **kwargs):
+        super(UUIDField, self).__init__(**kwargs)
+
+    def to_python(self, value):
+        if not isinstance(value, basestring):
+            value = unicode(value)
+        return uuid.UUID(value)
+
+    def to_mongo(self, value):
+        return unicode(value)
+
+    def validate(self, value):
+        if not isinstance(value, uuid.UUID):
+            if not isinstance(value, basestring):
+                value = str(value)
+            try:
+                value = uuid.UUID(value)
+            except Exception, exc:
+                raise ValidationError('Could not convert to UUID: %s' % exc)

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -1,9 +1,7 @@
 import unittest
 import datetime
 from decimal import Decimal
-
-import pymongo
-import gridfs
+import uuid
 
 from mongoengine import *
 from mongoengine.connection import _get_db
@@ -173,6 +171,26 @@ class FieldTest(unittest.TestCase):
         person.admin = 2
         self.assertRaises(ValidationError, person.validate)
         person.admin = 'Yes'
+        self.assertRaises(ValidationError, person.validate)
+
+    def test_uuid_validation(self):
+        """Ensure that invalid values cannot be assigned to UUID fields.
+        """
+        class Person(Document):
+            api_key = UUIDField()
+
+        person = Person()
+        # any uuid type is valid
+        person.api_key = uuid.uuid4()
+        person.validate()
+        person.api_key = uuid.uuid1()
+        person.validate()
+
+        # last g cannot belong to an hex number
+        person.api_key = '9d159858-549b-4975-9f98-dd2f987c113g'
+        self.assertRaises(ValidationError, person.validate)
+        # short strings don't validate
+        person.api_key = '9d159858-549b-4975-9f98-dd2f987c113'
         self.assertRaises(ValidationError, person.validate)
 
     def test_datetime_validation(self):


### PR DESCRIPTION
UUID fields are typically used to generate unique keys (like OIDs) and supported in pymongo and other ORMs/ODMs.
It's good to have them available with their integrity rules instead of treating them as simple strings.
