### PR TITLE
Fix queryset iteration

### DIFF
--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -1342,6 +1342,7 @@ class QuerySet(object):
             raise OperationError(u'Update failed [%s]' % unicode(e))
 
     def __iter__(self):
+        self.rewind()
         return self
 
     def _sub_js_fields(self, code):

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -567,7 +567,13 @@ class QuerySetTest(unittest.TestCase):
         people1 = [person for person in queryset]
         people2 = [person for person in queryset]
 
+        # Check that it still works even if iteration is interrupted.
+        for person in queryset:
+            break
+        people3 = [person for person in queryset]
+
         self.assertEqual(people1, people2)
+        self.assertEqual(people1, people3)
 
     def test_repr_iteration(self):
         """Ensure that QuerySet __repr__ can handle loops


### PR DESCRIPTION
Hi Harry!

Found a bug in queryset iteration - if an iteration got stopped for some reason (e.g. a break) then when you made a new iterator it started from the point the previous one got stopped. I've added a `self.rewind` into the `__iter__` which fixes it. I'm not completely sure of the speed implications of this, but it didn't break any tests. I've also added a now-passing amendment to the relevant test.

Marc
