### PR TITLE
Patch for issue #290

### DIFF
--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -722,15 +722,17 @@ class QuerySet(object):
         .. versionadded:: 0.3
         """
         self.__call__(*q_objs, **query)
-        count = self.count()
-        if count == 1:
-            return self[0]
-        elif count > 1:
-            message = u'%d items returned, instead of 1' % count
-            raise self._document.MultipleObjectsReturned(message)
-        else:
+        try:
+            result1 = self[0]
+        except IndexError:
             raise self._document.DoesNotExist("%s matching query does not exist."
                                               % self._document._class_name)
+        try:
+            result2 = self[1]
+        except IndexError:
+            return result1
+        message = u'%d items returned, instead of 1' % self.count()
+        raise self._document.MultipleObjectsReturned(message)
 
     def get_or_create(self, write_options=None, *q_objs, **query):
         """Retrieve unique object or create, if it doesn't exist. Returns a tuple of


### PR DESCRIPTION
Check for a first result, then check for a second. If the first is
missing, raise an error; if the second is present, raise an error;
otherwise return the first result.

I've left the inefficiency in place in the event of multiple matches,
as a count() is still needed to determine how many there were.
This leaves the code efficient in the "normal" case of a single
match, and potentially slow in the error case.
