### PR TITLE
Fixes a bug on connection and make use of depth parameter on dereference

### DIFF
--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -705,14 +705,17 @@ class BaseDocument(object):
             cls = subclasses[class_name]
 
         present_fields = data.keys()
+        changed_fields = []
         for field_name, field in cls._fields.items():
             if field.db_field in data:
                 value = data[field.db_field]
                 data[field_name] = (value if value is None
                                     else field.to_python(value))
+            else:
+                changed_fields.append(field_name)
 
         obj = cls(**data)
-        obj._changed_fields = []
+        obj._changed_fields = changed_fields
         return obj
     
     def _mark_as_changed(self, key):
@@ -790,7 +793,6 @@ class BaseDocument(object):
             set_data = doc
             if '_id' in set_data:
                 del(set_data['_id'])
-        
         return set_data, unset_data
 
     @classmethod

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -730,7 +730,6 @@ class BaseDocument(object):
         from mongoengine import EmbeddedDocument
         _changed_fields = []
         _changed_fields += getattr(self, '_changed_fields', [])
-        _changed_fields += getattr(self, '_initialized_fields', [])
         
         inspected = inspected or set()
         if hasattr(self, 'id'):
@@ -792,7 +791,7 @@ class BaseDocument(object):
             if '_id' in set_data:
                 del(set_data['_id'])
         
-        return set_data, {}
+        return set_data, unset_data
 
     @classmethod
     def _geo_indices(cls, inspected_classes=None):

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -28,7 +28,10 @@ def _get_connection(reconnect=False):
     global _connection
     identity = get_identity()
     # Connect to the database if not already connected
-    if _connection.get(identity) is None or reconnect:
+    cur = _connection.get(identity)
+    if cur is None or reconnect:
+        if cur:
+            cur.disconnect()
         try:
             _connection[identity] = Connection(**_connection_settings)
         except Exception, e:

--- a/tests/dereference.py
+++ b/tests/dereference.py
@@ -294,10 +294,10 @@ class FieldTest(unittest.TestCase):
             self.assertEqual(q, 4)
 
             [m for m in group_obj.members]
-            self.assertEqual(q, 4)
+            self.assertEqual(q, 7)
 
             [m for m in group_obj.members]
-            self.assertEqual(q, 4)
+            self.assertEqual(q, 7)
 
             for m in group_obj.members:
                 self.assertTrue('User' in m.__class__.__name__)
@@ -309,12 +309,12 @@ class FieldTest(unittest.TestCase):
             group_objs = Group.objects.select_related()
             self.assertEqual(q, 4)
 
-            for group_obj in group_objs:
+            for k, group_obj in enumerate(group_objs):
                 [m for m in group_obj.members]
-                self.assertEqual(q, 4)
+                self.assertEqual(q, [7, 10][k])
 
                 [m for m in group_obj.members]
-                self.assertEqual(q, 4)
+                self.assertEqual(q, [7, 10][k])
 
                 for m in group_obj.members:
                     self.assertTrue('User' in m.__class__.__name__)
@@ -631,10 +631,10 @@ class FieldTest(unittest.TestCase):
             self.assertEqual(q, 2)
 
             [m for m in group_obj.members]
-            self.assertEqual(q, 2)
+            self.assertEqual(q, 3)
 
             [m for m in group_obj.members]
-            self.assertEqual(q, 2)
+            self.assertEqual(q, 3)
 
             for k, m in group_obj.members.iteritems():
                 self.assertTrue(isinstance(m, UserA))
@@ -646,12 +646,12 @@ class FieldTest(unittest.TestCase):
             group_objs = Group.objects.select_related()
             self.assertEqual(q, 2)
 
-            for group_obj in group_objs:
+            for k, group_obj in enumerate(group_objs):
                 [m for m in group_obj.members]
-                self.assertEqual(q, 2)
+                self.assertEqual(q, [3, 4][k])
 
                 [m for m in group_obj.members]
-                self.assertEqual(q, 2)
+                self.assertEqual(q, [3, 4][k])
 
                 for k, m in group_obj.members.iteritems():
                     self.assertTrue(isinstance(m, UserA))
@@ -719,10 +719,10 @@ class FieldTest(unittest.TestCase):
             self.assertEqual(q, 4)
 
             [m for m in group_obj.members]
-            self.assertEqual(q, 4)
+            self.assertEqual(q, 7)
 
             [m for m in group_obj.members]
-            self.assertEqual(q, 4)
+            self.assertEqual(q, 7)
 
             for k, m in group_obj.members.iteritems():
                 self.assertTrue('User' in m.__class__.__name__)
@@ -734,12 +734,12 @@ class FieldTest(unittest.TestCase):
             group_objs = Group.objects.select_related()
             self.assertEqual(q, 4)
 
-            for group_obj in group_objs:
+            for k, group_obj in enumerate(group_objs):
                 [m for m in group_obj.members]
-                self.assertEqual(q, 4)
+                self.assertEqual(q, [7, 10][k])
 
                 [m for m in group_obj.members]
-                self.assertEqual(q, 4)
+                self.assertEqual(q, [7, 10][k])
 
                 for k, m in group_obj.members.iteritems():
                     self.assertTrue('User' in m.__class__.__name__)

--- a/tests/document.py
+++ b/tests/document.py
@@ -1440,12 +1440,12 @@ class DocumentTest(unittest.TestCase):
         doc._changed_fields = []
         doc.dict_field = {}
         self.assertEquals(doc._get_changed_fields(), ['dict_field'])
-        self.assertEquals(doc._delta(), ({}, {'dict_field': 1}))
+        self.assertEquals(doc._delta(), ({'dict_field': {}}, {}))
 
         doc._changed_fields = []
         doc.list_field = []
         self.assertEquals(doc._get_changed_fields(), ['list_field'])
-        self.assertEquals(doc._delta(), ({}, {'list_field': 1}))
+        self.assertEquals(doc._delta(), ({'list_field': []}, {}))
 
     def test_delta_recursive(self):
 
@@ -1495,16 +1495,16 @@ class DocumentTest(unittest.TestCase):
 
         doc.embedded_field.dict_field = {}
         self.assertEquals(doc._get_changed_fields(), ['embedded_field.dict_field'])
-        self.assertEquals(doc.embedded_field._delta(), ({}, {'dict_field': 1}))
-        self.assertEquals(doc._delta(), ({}, {'embedded_field.dict_field': 1}))
+        self.assertEquals(doc.embedded_field._delta(), ({'dict_field': {}}, {}))
+        self.assertEquals(doc._delta(), ({'embedded_field.dict_field': {}}, {}))
         doc.save()
         doc.reload()
         self.assertEquals(doc.embedded_field.dict_field, {})
 
         doc.embedded_field.list_field = []
         self.assertEquals(doc._get_changed_fields(), ['embedded_field.list_field'])
-        self.assertEquals(doc.embedded_field._delta(), ({}, {'list_field': 1}))
-        self.assertEquals(doc._delta(), ({}, {'embedded_field.list_field': 1}))
+        self.assertEquals(doc.embedded_field._delta(), ({'list_field': []}, {}))
+        self.assertEquals(doc._delta(), ({'embedded_field.list_field': []}, {}))
         doc.save()
         doc.reload()
         self.assertEquals(doc.embedded_field.list_field, [])
@@ -1602,7 +1602,7 @@ class DocumentTest(unittest.TestCase):
         doc.reload()
 
         del(doc.embedded_field.list_field[2].list_field)
-        self.assertEquals(doc._delta(), ({}, {'embedded_field.list_field.2.list_field': 1}))
+        self.assertEquals(doc._delta(), ({'embedded_field.list_field.2.list_field': []}, {}))
 
         doc.save()
         doc.reload()
@@ -1657,12 +1657,12 @@ class DocumentTest(unittest.TestCase):
         doc._changed_fields = []
         doc.dict_field = {}
         self.assertEquals(doc._get_changed_fields(), ['db_dict_field'])
-        self.assertEquals(doc._delta(), ({}, {'db_dict_field': 1}))
+        self.assertEquals(doc._delta(), ({'db_dict_field': {}}, {}))
 
         doc._changed_fields = []
         doc.list_field = []
         self.assertEquals(doc._get_changed_fields(), ['db_list_field'])
-        self.assertEquals(doc._delta(), ({}, {'db_list_field': 1}))
+        self.assertEquals(doc._delta(), ({'db_list_field': []}, {}))
 
         # Test it saves that data
         doc = Doc()
@@ -1728,16 +1728,16 @@ class DocumentTest(unittest.TestCase):
 
         doc.embedded_field.dict_field = {}
         self.assertEquals(doc._get_changed_fields(), ['db_embedded_field.db_dict_field'])
-        self.assertEquals(doc.embedded_field._delta(), ({}, {'db_dict_field': 1}))
-        self.assertEquals(doc._delta(), ({}, {'db_embedded_field.db_dict_field': 1}))
+        self.assertEquals(doc.embedded_field._delta(), ({'db_dict_field': {}}, {}))
+        self.assertEquals(doc._delta(), ({'db_embedded_field.db_dict_field': {}}, {}))
         doc.save()
         doc.reload()
         self.assertEquals(doc.embedded_field.dict_field, {})
 
         doc.embedded_field.list_field = []
         self.assertEquals(doc._get_changed_fields(), ['db_embedded_field.db_list_field'])
-        self.assertEquals(doc.embedded_field._delta(), ({}, {'db_list_field': 1}))
-        self.assertEquals(doc._delta(), ({}, {'db_embedded_field.db_list_field': 1}))
+        self.assertEquals(doc.embedded_field._delta(), ({'db_list_field': []}, {}))
+        self.assertEquals(doc._delta(), ({'db_embedded_field.db_list_field': []}, {}))
         doc.save()
         doc.reload()
         self.assertEquals(doc.embedded_field.list_field, [])
@@ -1835,7 +1835,7 @@ class DocumentTest(unittest.TestCase):
         doc.reload()
 
         del(doc.embedded_field.list_field[2].list_field)
-        self.assertEquals(doc._delta(), ({}, {'db_embedded_field.db_list_field.2.db_list_field': 1}))
+        self.assertEquals(doc._delta(), ({'db_embedded_field.db_list_field.2.db_list_field': []}, {}))
 
     def test_save_only_changed_fields(self):
         """Ensure save only sets / unsets changed fields

--- a/tests/document.py
+++ b/tests/document.py
@@ -1867,6 +1867,38 @@ class DocumentTest(unittest.TestCase):
         self.assertEquals(person.age, 21)
         self.assertEquals(person.active, False)
 
+    def test_new_embedded_documents(self):
+        """Ensure saving of new embedded document fields if model class changes
+        """
+        class B(EmbeddedDocument):
+            field1 = StringField(default='field1')
+        
+        class A(Document):
+            b = EmbeddedDocumentField(B, default=lambda: B())
+        
+        A.drop_collection()
+        a = A()
+        a.save()
+        a.reload()
+        self.assertEquals(a.b.field1, 'field1')
+        
+        class C(EmbeddedDocument):
+            c_field = StringField(default='cfield')
+        
+        class B(EmbeddedDocument):
+            field1 = StringField(default='field1')
+            field2 = EmbeddedDocumentField(C, default=lambda: C())
+        
+        class A(Document):
+            b = EmbeddedDocumentField(B, default=lambda: B())
+        
+        a = A.objects()[0]
+        a.b.field2.c_field = 'new value'
+        a.save()
+        
+        a.reload()
+        self.assertEquals(a.b.field2.c_field, 'new value')
+
     def test_save_only_changed_fields_recursive(self):
         """Ensure save only sets / unsets changed fields
         """


### PR DESCRIPTION
Hi!

I've found a bug on connection.py that would replace previews open connections with new connections when reconnect is True. It basically calls disconnect() on the old connection if it exists.

I've also changed dereference.py to make use of the depth parameter to avoid loading a large number of objects when they are not needed. Also changed the tests to match the new query counters as there will be more queries now as loading objects deeper into the tree are needed.

Hope this helps,
## 

JP
