### PR TITLE
Add a aggregate_to_python method to BaseField, which allows customization of the data returned by QuerySet.sum and QuerySet.average

### DIFF
--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -116,6 +116,11 @@ class BaseField(object):
         instance._data[self.name] = value
         instance._mark_as_changed(self.name)
 
+    def qs_to_python(self, value):
+        """Converts a MongoDB queryset to a Python type.
+        """
+        return value
+
     def to_python(self, value):
         """Convert a MongoDB-compatible type to a Python type.
         """

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -116,8 +116,9 @@ class BaseField(object):
         instance._data[self.name] = value
         instance._mark_as_changed(self.name)
 
-    def qs_to_python(self, value):
-        """Converts a MongoDB queryset to a Python type.
+    def aggregate_to_python(self, value):
+        """Values returned by queryset.sum(field) and
+        queryset.average(field) evaluated by this method.
         """
         return value
 

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -966,6 +966,16 @@ class QuerySet(object):
             yield MapReduceDocument(self._document, self._collection,
                                     doc['_id'], doc['value'])
 
+    def _get_qs_to_python(self, field):
+        """This will return the qs_to_python method for a document
+        field-attribute, given the mongodb field name.
+        """
+        # Check in the _db_reverse_field_map which contains fieldnames
+        # for db fields with a different name the the model attribute
+        # name, else default to field.
+        attr = self._document._reverse_db_field_map.get(field, field)
+        return getattr(self._document, attr).qs_to_python
+
     def limit(self, n):
         """Limit the number of returned documents to `n`. This may also be
         achieved using array-slicing syntax (e.g. ``User.objects[:5]``).
@@ -1451,10 +1461,12 @@ class QuerySet(object):
             }
         """)
 
+        qs_to_python = self._get_qs_to_python(field)
+
         for result in self.map_reduce(map_func, reduce_func, output='inline'):
-            return result.value
+            return qs_to_python(result.value)
         else:
-            return 0
+            return qs_to_python(0)
 
     def average(self, field):
         """Average over the values of the specified field.
@@ -1490,10 +1502,12 @@ class QuerySet(object):
             }
         """)
 
+        qs_to_python = self._get_qs_to_python(field)
+
         for result in self.map_reduce(map_func, reduce_func, finalize_f=finalize_func, output='inline'):
-            return result.value
+            return qs_to_python(result.value)
         else:
-            return 0
+            return qs_to_python(0)
 
     def item_frequencies(self, field, normalize=False, map_reduce=True):
         """Returns a dictionary of all items present in a field across

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -966,15 +966,15 @@ class QuerySet(object):
             yield MapReduceDocument(self._document, self._collection,
                                     doc['_id'], doc['value'])
 
-    def _get_qs_to_python(self, field):
-        """This will return the qs_to_python method for a document
+    def _get_aggregate_to_python(self, field):
+        """This will return the aggregate_to_python method for a document
         field-attribute, given the mongodb field name.
         """
         # Check in the _db_reverse_field_map which contains fieldnames
         # for db fields with a different name the the model attribute
         # name, else default to field.
         attr = self._document._reverse_db_field_map.get(field, field)
-        return getattr(self._document, attr).qs_to_python
+        return getattr(self._document, attr).aggregate_to_python
 
     def limit(self, n):
         """Limit the number of returned documents to `n`. This may also be
@@ -1461,12 +1461,12 @@ class QuerySet(object):
             }
         """)
 
-        qs_to_python = self._get_qs_to_python(field)
+        aggregate_to_python = self._get_aggregate_to_python(field)
 
         for result in self.map_reduce(map_func, reduce_func, output='inline'):
-            return qs_to_python(result.value)
+            return aggregate_to_python(result.value)
         else:
-            return qs_to_python(0)
+            return aggregate_to_python(0)
 
     def average(self, field):
         """Average over the values of the specified field.
@@ -1502,12 +1502,12 @@ class QuerySet(object):
             }
         """)
 
-        qs_to_python = self._get_qs_to_python(field)
+        aggregate_to_python = self._get_aggregate_to_python(field)
 
         for result in self.map_reduce(map_func, reduce_func, finalize_f=finalize_func, output='inline'):
-            return qs_to_python(result.value)
+            return aggregate_to_python(result.value)
         else:
-            return qs_to_python(0)
+            return aggregate_to_python(0)
 
     def item_frequencies(self, field, normalize=False, map_reduce=True):
         """Returns a dictionary of all items present in a field across

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -1879,7 +1879,7 @@ class QuerySetTest(unittest.TestCase):
                 name='test%s' % i, age=age, worth=Decimal(worths[i])).save()
 
         avg_worth = Decimal(str(round(sum(worths) / len(worths), 2)))
-        avg = sum(ages) / (len(ages) + 1) # take into account the 0
+        avg = float(sum(ages)) / (len(ages) + 1) # take into account the 0
         self.assertAlmostEqual(int(self.Person.objects.average('age')), avg)
 
         # Here I test that the average works on a custom field type.

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -20,7 +20,7 @@ class QuerySetTest(unittest.TestCase):
         class MoneyField(IntField):
             """
             This is an example of a custom field type with to_python,
-            qs_to_python and to_mongo methods.
+            aggregate_to_python and to_mongo methods.
             """
             def __init__(
                 self, min_value=None, max_value=None, \
@@ -32,7 +32,7 @@ class QuerySetTest(unittest.TestCase):
             def _round(self, value):
                 return Decimal(str(round(value, self.decimal_digits)))
 
-            def qs_to_python(self, value):
+            def aggregate_to_python(self, value):
                 return self.to_python(value)
 
             def to_python(self, value):
@@ -1886,7 +1886,7 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(self.Person.objects.average('worth'), avg_worth)
 
         # Here I test that the average datatype is the datatype set in
-        # Field.qs_to_python.
+        # Field.aggregate_to_python.
         self.assertTrue(
             isinstance(self.Person.objects.average('worth'), Decimal))
 
@@ -1909,7 +1909,7 @@ class QuerySetTest(unittest.TestCase):
             int(self.Person.objects.sum('worth')), sum(worths))
 
         # Here I test that the sum datatype is the datatype set in
-        # Field.qs_to_python.
+        # Field.aggregate_to_python.
         self.assertTrue(isinstance(self.Person.objects.sum('worth'), Decimal))
 
         self.Person(name='ageless person').save()


### PR DESCRIPTION
I noticed that you cannot easily change the datatype and/or actual data returned by queryset.sum(), this is sometimes useful when writing a BaseField subclass for things like Currency.

I added a "aggregate_to_python" method to BaseField. Any data returned by QuerySet.sum or QuerySet.average is passed to the field's aggregate_to_python method before being returned.

I also added a few lines to mongoengine/tests/queryset.py that ensures the proper behaviour for custom fields with a aggregate_to_python method.
