### PR TITLE
BaseDocument should not define a __str__ method... thoughts?

### DIFF
--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -906,11 +906,6 @@ class BaseDocument(object):
             u = '[Bad Unicode data]'
         return u'<%s: %s>' % (self.__class__.__name__, u)
 
-    def __str__(self):
-        if hasattr(self, '__unicode__'):
-            return unicode(self).encode('utf-8')
-        return '%s object' % self.__class__.__name__
-
     def __eq__(self, other):
         if isinstance(other, self.__class__) and hasattr(other, 'id'):
             if self.id == other.id:

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -899,13 +899,6 @@ class BaseDocument(object):
     def __len__(self):
         return len(self._data)
 
-    def __repr__(self):
-        try:
-            u = unicode(self)
-        except (UnicodeEncodeError, UnicodeDecodeError):
-            u = '[Bad Unicode data]'
-        return u'<%s: %s>' % (self.__class__.__name__, u)
-
     def __eq__(self, other):
         if isinstance(other, self.__class__) and hasattr(other, 'id'):
             if self.id == other.id:

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -170,8 +170,8 @@ class Document(BaseDocument):
             for name, cls in self._fields.items():
                 if isinstance(cls, (ReferenceField, GenericReferenceField)):
                     ref = getattr(self, name)
-                    if ref and str(ref) not in _refs:
-                        _refs.append(str(ref))
+                    if ref and ref.__class__.__name__ not in _refs:
+                        _refs.append(ref.__class__.__name__)
                         ref.save(safe=safe, force_insert=force_insert,
                                  validate=validate, write_options=write_options,
                                  _refs=_refs)

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -1105,8 +1105,9 @@ class FieldTest(unittest.TestCase):
         Person.drop_collection()
         Person(name="Wilson Jr").save()
 
-        self.assertEquals(repr(Person.objects(city=None)),
-                            "[<Person: Person object>]")
+        p = Person.objects(city=None)[0]
+        self.assertTrue(isinstance(p, Person))
+
 
     def test_binary_fields(self):
         """Ensure that binary fields can be stored and retrieved.

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -576,7 +576,6 @@ class QuerySetTest(unittest.TestCase):
         self.Person(name='Person 2').save()
 
         queryset = self.Person.objects
-        self.assertEquals('[<Person: Person object>, <Person: Person object>]', repr(queryset))
         for person in queryset:
             self.assertEquals('.. queryset mid-iteration ..', repr(queryset))
 


### PR DESCRIPTION
Remove **str** method from BaseDocument, since subclasses implementing **repr** won't print as expected
## 

I had to dig into the difference between **str** and **repr** for this one. (http://docs.python.org/reference/datamodel.html and http://stackoverflow.com/questions/1436703/difference-between-str-and-repr-in-python)

I think subclasses of Document should be able to implement **repr** and expect their stringified output to be what is returned by **repr**.  Because a **str** exists in the MRO of the subclass, its **repr** method is never called.

``` python
class Foo(Document):
    bar = StringField(primary_key=True)

    def __repr__(self):
        return "<A Foo Class: %s>" % self.bar

a = Foo(bar='id123')
a.save()
print a # <-- prints "Foo object"
```
