### PR TITLE
Fix/test for ReferenceFields being saved when they are unchanged

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -189,14 +189,12 @@ class Document(BaseDocument):
 
             inspected_docs = inspected_docs or []
             inspected_docs.append(doc)
-            if hasattr(doc, '_changed_fields'):
-                doc._changed_fields = []
+            doc._changed_fields = []
 
             for field_name in doc._fields:
                 field = getattr(doc, field_name)
                 if field not in inspected_docs and hasattr(field, '_changed_fields'):
                     reset_changed_fields(field, inspected_docs)
-
         reset_changed_fields(self)
         signals.post_save.send(self.__class__, document=self, created=creation_mode)
 

--- a/tests/document.py
+++ b/tests/document.py
@@ -2345,6 +2345,32 @@ class DocumentTest(unittest.TestCase):
 
         self.assertRaises(InvalidDocumentError, throw_invalid_document_error)
 
+    def test_do_not_save_unchanged_references(self):
+        class Job(Document):
+            name = StringField()
+
+        class Person(Document):
+            name = StringField()
+            age = IntField()
+            job = ReferenceField(Job)
+
+        job = Job(name="Job 1")
+        # job should not have any changed fields after the save
+        job.save()
+
+        person = Person(name="name", age=10, job=job)
+
+        from pymongo.collection import Collection
+        orig_update = Collection.update
+        try:
+            def fake_update(*args, **kwargs):
+		self.fail("Unexpected update for %s" % args[0].name)
+                return orig_update(*args, **kwargs)
+
+            Collection.update = fake_update
+            person.save()
+        finally:
+            Collection.update = orig_update
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If you save a Document that contains a ReferenceField, the ReferenceField is saved again even if it does not have any outstanding changes.
This particular bug only happens when you assign a newly created and saved Document to the ReferenceField as opposed to assigning a Document that
was loaded from the DB.

E.g.
  a = Document()
  a.save()

  b.a = a
  b.save() # a is saved again incorrectly

vs.

  a = Document.find(...)
  b.a = a
  b.save() # only b is saved
