### PR TITLE
PyPy

### DIFF
--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -480,6 +480,8 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
                     base_meta['queryset_class'] = base._meta['queryset_class']
             try:
                 base_meta['objects'] = base.__getattribute__(base, 'objects')
+            except TypeError:
+                pass
             except AttributeError:
                 pass
 


### PR DESCRIPTION
Hi, this should get mongoengine running on PyPy. Tests pass all but one. I have no idea if this test has something to do with my change. See:
## FAIL: Tests showing pymongo datetime fields handling of microseconds.

Traceback (most recent call last):
  File "/x/y/z/mongoengine/tests/fields.py", line 259, in test_datetime
    self.assertEquals(delta.seconds, 16)
AssertionError: 86399 != 16

Not sure if this is the only change required, using PyPy all tests pass but 2:

FAIL: test_datetime (tests.fields.FieldTest)
## Tests showing pymongo datetime fields handling of microseconds.

Traceback (most recent call last):
  File "/Users/ivan/eelogic-pypy/src/mongoengine/tests/fields.py", line 259, in test_datetime
    self.assertEquals(delta.seconds, 16)
AssertionError: 86399 != 16
# 

FAIL: test_custom_querysets_inherited_direct (tests.queryset.QuerySetTest)
## Ensure that custom QuerySet classes may be used.

Traceback (most recent call last):
  File "/Users/ivan/eelogic-pypy/src/mongoengine/tests/queryset.py", line 2389, in test_custom_querysets_inherited_direct
    self.assertTrue(isinstance(Post.objects, CustomQuerySet))
AssertionError: False is not True

--Ivan
