### PR TITLE
typo fix

### DIFF
--- a/docs/guide/signals.rst
+++ b/docs/guide/signals.rst
@@ -9,7 +9,7 @@ Signal support is provided by the excellent `blinker`_ library and
 will gracefully fall back if it is not available.
 
 
-The following document signals exist in MongoEngine and are pretty self explaintary:
+The following document signals exist in MongoEngine and are pretty self-explanatory:
 
   * `mongoengine.signals.pre_init`
   * `mongoengine.signals.post_init`


### PR DESCRIPTION
I'll eventually write up something on each signal, since I didn't think the pre_init and post_init signals were self-explanatory for those new to mongo.
