### PR TITLE
implement __nonzero__ for querysets

### DIFF
--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -875,6 +875,9 @@ class QuerySet(object):
 
     def __len__(self):
         return self.count()
+       
+    def __nonzero__(self):
+        return bool(self.first())
 
     def map_reduce(self, map_f, reduce_f, output, finalize_f=None, limit=None,
                    scope=None):


### PR DESCRIPTION
Without **nonzero** implemented, **len** is used to boolean testing, which causing count to be called. This is not efficient. We can just check to see any elements exists by looking for the existence of the first element.

Using find_one is probably more efficient, but this was a simpler solution for now. 
