### PR TITLE
Made QuerySet select all declared fields, instead of all fields by default 

### DIFF
--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -327,7 +327,7 @@ class QuerySet(object):
         self._query_obj = Q()
         self._initial_query = {}
         self._where_clause = None
-        self._loaded_fields = QueryFieldList()
+        self._loaded_fields = QueryFieldList(document._fields.iterkeys())
         self._ordering = []
         self._snapshot = False
         self._timeout = True

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -971,6 +971,23 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(obj.content_type, 'text/plain')
 
         Email.drop_collection()
+    
+    def test_not_declared_field_with_colliding_property(self):
+        class Email(Document):
+            meta = {"allow_inheritance":False}
+            subject = StringField()
+            body = StringField()
+            
+            @property
+            def body_length(self):
+                return len(self.body)
+        
+        Email.objects._collection.insert({"subject":"Hello World!", "body":"I am alive", "body_length":10}, safe=True)
+        email = Email.objects.get()
+        
+        self.assertEqual(email.subject, "Hello World!")
+        self.assertEqual(email.body, "I am alive")
+        self.assertEqual(email.body_length, 10)
 
     def test_slicing_fields(self):
         """Ensure that query slicing an array works.


### PR DESCRIPTION
Made the QuerySet._loaded_fields attribute default to a QueryFieldList with the document's all fields selected.

This fixes a bug that occurs when you have a field in the database, that is _not_ declared as a field in the MongoEngine document, when the document has a property function with the same name.

This is quite a common use case when doing refactoring and your dataset is too large to run an $unset update query on.

All the tests passes, and a test is supplied for the described bug. I hope you think this is good :), but since you know the codebase best please tell me if it should be done in some other way.
