### PR TITLE
Add new meta option to Document: allow_index_creation.

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -74,6 +74,11 @@ class Document(BaseDocument):
     names. Index direction may be specified by prefixing the field names with
     a **+** or **-** sign.
 
+    Index creation can be disabled by specifying :attr:`index_allow_creation` in
+    the :attr:`meta` dictionary. If this is set to True then indexes will not be
+    created by MongoEngine. This is useful in production systems where index
+    creation is performed as part of a deployment system.
+
     By default, _types will be added to the start of every index (that
     doesn't contain a list) if allow_inheritence is True. This can be
     disabled by either setting types to False on the specific index or

--- a/tests/document.py
+++ b/tests/document.py
@@ -740,6 +740,28 @@ class DocumentTest(unittest.TestCase):
         self.assertEqual(info.keys(), ['_types_1_user_guid_1', '_id_', '_types_1_name_1'])
         Person.drop_collection()
 
+    def test_disable_index_creation(self):
+        """Tests setting allow_index_creation to False on the connection will
+        disable any index generation.
+        """
+        class User(Document):
+            meta = {
+                'indexes': ['user_guid'],
+                'index_allow_creation': False
+            }
+            user_guid = StringField(required=True)
+
+
+        User.drop_collection()
+
+        u = User(user_guid='123')
+        u.save()
+
+        self.assertEquals(1, User.objects.count())
+        info = User.objects._collection.index_information()
+        self.assertEqual(info.keys(), ['_id_'])
+        User.drop_collection()
+
     def test_embedded_document_index(self):
         """Tests settings an index on an embedded document
         """


### PR DESCRIPTION
Defaults to True. If set to False then MongoEngine will not ensure indexes exist
