### PR TITLE
Fix session data loss on first session save

### DIFF
--- a/mongoengine/django/sessions.py
+++ b/mongoengine/django/sessions.py
@@ -51,9 +51,7 @@ class SessionStore(SessionBase):
             return
 
     def save(self, must_create=False):
-        if self._session_key is None:
-            self.create()
-        s = MongoSession(session_key=self._session_key)
+        s = MongoSession(session_key=self._get_or_create_session_key())
         s.session_data = self.encode(self._get_session(no_load=must_create))
         s.expire_date = self.get_expiry_date()
         try:

--- a/mongoengine/django/sessions.py
+++ b/mongoengine/django/sessions.py
@@ -51,7 +51,9 @@ class SessionStore(SessionBase):
             return
 
     def save(self, must_create=False):
-        s = MongoSession(session_key=self._get_or_create_session_key())
+        if self.session_key is None:
+            self._session_key = self._get_new_session_key()
+        s = MongoSession(session_key=self.session_key)
         s.session_data = self.encode(self._get_session(no_load=must_create))
         s.expire_date = self.get_expiry_date()
         try:


### PR DESCRIPTION
Same implementation is in 'django/contrib/sessions/backends/db.py'.

Bug is here:

SessionStore#save() is called for new session
SessionStore#session_key is None so SessionStore#create() is called
SessionStore#save(must_create=True) called from SessionStore#create() and data from SessionStore#_session_cache is saved
but then original SessionStore#save() continues and rewrites session_data with empty SessionStore#_session_cache (it was cleared in SessionStore#create()).
