### PR TITLE
refactor get_connection

### DIFF
--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -39,22 +39,7 @@ def register_connection(alias, name, host='localhost', port=27017,
     """
     global _connection_settings
 
-    # Handle uri style connections
-    if "://" in host:
-        uri_dict = uri_parser.parse_uri(host)
-        if uri_dict.get('database') is None:
-            raise ConnectionError("If using URI style connection include "\
-                                  "database name in string")
-        _connection_settings[alias] = {
-            'host': host,
-            'name': uri_dict.get('database'),
-            'username': uri_dict.get('username'),
-            'password': uri_dict.get('password')
-        }
-        _connection_settings[alias].update(kwargs)
-        return
-
-    _connection_settings[alias] = {
+    conn_settings = {
         'name': name,
         'host': host,
         'port': port,
@@ -64,7 +49,22 @@ def register_connection(alias, name, host='localhost', port=27017,
         'password': password,
         'read_preference': read_preference
     }
-    _connection_settings[alias].update(kwargs)
+
+    # Handle uri style connections
+    if "://" in host:
+        uri_dict = uri_parser.parse_uri(host)
+        if uri_dict.get('database') is None:
+            raise ConnectionError("If using URI style connection include "\
+                                  "database name in string")
+        conn_settings.update({
+            'host': host,
+            'name': uri_dict.get('database'),
+            'username': uri_dict.get('username'),
+            'password': uri_dict.get('password'),
+            'read_preference': read_preference,
+        })
+
+    _connection_settings[alias] = conn_settings
 
 
 def disconnect(alias=DEFAULT_CONNECTION_NAME):


### PR DESCRIPTION
In the previous version, the requested ReadPreference was ignored in the
case that the user specified a MongoDB URI. This rearranges the code to
ensure that only those values which we explicitly parse out of the URI
override values set as keyword arguments.

This leaves open the possibility of conflicts between the URI and the
kwargs -- we should consider whether to raise an exception if, e.g.,
username is specified as a kwarg _and_ in the URI.
