### PR TITLE
Fixed Document with Proxied Fields Deletion Logic for EmbeddedDocuments

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -281,8 +281,13 @@ class Document(BaseDocument):
             for field_name in self._meta['proxy_fields']:
                 proxy_class = self._meta['proxy_fields'][field_name]
                 if hasattr(proxy_class, 'delete'):
-                    proxy = getattr(self, field_name)
-                    proxy.delete()
+                    sub_fields = field_name.split(".")
+                    obj = self
+                    while sub_fields:
+                        sub_f = sub_fields.pop(0)
+                        attr = getattr(obj, sub_f)
+                        obj = attr
+                    obj.delete()
             self.__class__.objects(pk=self.pk).delete(safe=safe)
         except pymongo.errors.OperationFailure, err:
             message = u'Could not delete document (%s)' % err.message
@@ -346,13 +351,6 @@ class Document(BaseDocument):
         object.
         """
         cls._meta['delete_rules'][(document_cls, field_name)] = rule
-
-    @classmethod
-    def register_proxy_field(cls, field_name, proxy_class):
-        """This method registers fields with proxy classes to delete them when
-        removing this object.
-        """
-        cls._meta['proxy_fields'][field_name] = proxy_class
 
     @classmethod
     def drop_collection(cls):

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -1661,6 +1661,29 @@ class FieldTest(unittest.TestCase):
 
         self._verify_file_delete(testimage, 'image')
 
+    def test_document_delete_no_file_cleanup(self):
+        """Ensure that document deletion when a GridFSProxied
+        Field exists but is not present works as expected"""
+        class TestFile(Document):
+            f = FileField()
+
+        class TestImage(Document):
+            image = ImageField()
+
+        TestFile.drop_collection()
+
+        testfile = TestFile()
+        testfile.save()
+
+        self._verify_file_delete(testfile, 'f')
+
+        TestImage.drop_collection()
+
+        testimage = TestImage()
+        testimage.save()
+
+        self._verify_file_delete(testimage, 'image')
+
     def test_file_field_no_default(self):
 
         class GridDocument(Document):

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -1684,6 +1684,45 @@ class FieldTest(unittest.TestCase):
 
         self._verify_file_delete(testimage, 'image')
 
+    def test_embedded_file_delete_cleanup(self):
+        """Ensure that the gridfs file is deleted when a document
+        with an EmbeddedDocument and GridFSProxied Field is deleted"""
+        class EmbeddedFile(EmbeddedDocument):
+            f = FileField()
+
+        class TestFile(Document):
+            embed_file = EmbeddedDocumentField(EmbeddedFile)
+
+        class EmbeddedImage(EmbeddedDocument):
+            image = ImageField()
+
+        class TestImage(Document):
+            embed_image = EmbeddedDocumentField(EmbeddedImage)
+
+        TestFile.drop_collection()
+
+        testfile = TestFile()
+        testfile.embed_file = EmbeddedFile()
+        testfile.embed_file.f.put('Hello, World!')
+        testfile.save()
+
+        self._verify_file_delete(testfile, 'embed_file.f')
+
+        TestImage.drop_collection()
+
+        testimage = TestImage()
+        testimage.embed_image = EmbeddedImage()
+        testimage.embed_image.image.put(open(TEST_IMAGE_PATH, 'r'))
+        testimage.save()
+
+        self._verify_file_delete(testimage, 'embed_image.image')
+
+        testfile = TestFile()
+        testfile.embed_file = EmbeddedFile()
+        testfile.save()
+
+        self._verify_file_delete(testfile, 'embed_file.f')
+
     def test_file_field_no_default(self):
 
         class GridDocument(Document):


### PR DESCRIPTION
As pointed out in https://github.com/hmarr/mongoengine/pull/492#issuecomment-5616680 `FileField` and `ImageField` deletion breaks in `EmbeddedDocuments`.  This set of patches build on pull request 492 to recurse through the fields of an `EmbeddedDocument` to do the appropriate deletion there as well.
