### PR TITLE
Fixed MongoTestCase.

### DIFF
--- a/mongoengine/django/tests.py
+++ b/mongoengine/django/tests.py
@@ -10,6 +10,7 @@ class MongoTestCase(TestCase):
     """
     db_name = 'test_%s' % settings.MONGO_DATABASE_NAME
     def __init__(self, methodName='runtest'):
+        connection.disconnect()
         connect(self.db_name)
         super(MongoTestCase, self).__init__(methodName)
 

--- a/mongoengine/django/tests.py
+++ b/mongoengine/django/tests.py
@@ -2,7 +2,7 @@
 from django.test import TestCase
 from django.conf import settings
 
-from mongoengine import connect
+from mongoengine import connect, connection
 
 class MongoTestCase(TestCase):
     """
@@ -10,12 +10,12 @@ class MongoTestCase(TestCase):
     """
     db_name = 'test_%s' % settings.MONGO_DATABASE_NAME
     def __init__(self, methodName='runtest'):
-        self.db = connect(self.db_name)
+        connect(self.db_name)
         super(MongoTestCase, self).__init__(methodName)
 
     def _post_teardown(self):
         super(MongoTestCase, self)._post_teardown()
-        for collection in self.db.collection_names():
+        for collection in connection.get_db().collection_names():
             if collection == 'system.indexes':
                 continue
-            self.db.drop_collection(collection)
+            connection.get_db().drop_collection(collection)


### PR DESCRIPTION
Without this patch I am getting:

```
TypeError: 'Database' object is not callable. If you meant to call the 'collection_names' method on a 'Connection' object it is failing because no such method exists.
```

Using pymongo 2.2.
