### PR TITLE
Constraint the version of pymongo in the latest stable release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pymongo
+pymongo==2.1.1

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(name='mongoengine',
       long_description=LONG_DESCRIPTION,
       platforms=['any'],
       classifiers=CLASSIFIERS,
-      install_requires=['pymongo'],
+      install_requires=['pymongo==2.1.1'],
       test_suite='tests',
       tests_require=['blinker', 'django>=1.3', 'PIL']
 )


### PR DESCRIPTION
Currently, the pymongo dependency is not limited in releases, so a fresh install via pip downloads pymongo 2.2 which is incompatible with mongoengine.
