### PR TITLE
Add sensible __eq__ method to EmbeddedDocument

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -40,6 +40,11 @@ class EmbeddedDocument(BaseDocument):
         else:
             super(EmbeddedDocument, self).__delattr__(*args, **kwargs)
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self._data == other._data
+        return False
+
 
 class Document(BaseDocument):
     """The base class used for defining the structure and properties of


### PR DESCRIPTION
At the moment the comparison of embedded documents always return `False`, even if they are perfectly equal. It's because `EmbeddedDocument` inherits `__eq__` method form BaseDocument which tries to compare documents by IDs.

I've added the `__eq__` method which uses actual data to ascertain that embedded documents are equal.
