### PR TITLE
Feature: PULL reverse_delete_rule

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+Changes in 0.6.x
+=================
+- PULL reverse_delete_rule
+
 Changes in 0.6.10
 =================
 - Fixed basedict / baselist to return super(..)

--- a/docs/guide/defining-documents.rst
+++ b/docs/guide/defining-documents.rst
@@ -289,6 +289,10 @@ Its value can take any of the following constants:
 :const:`mongoengine.CASCADE`
   Any object containing fields that are refererring to the object being deleted
   are deleted first.
+:const:`mongoengine.PULL`
+  Removes the reference to the object (using MongoDB's "pull" operation)
+  from any object's fields of
+  :class:`~mongoengine.ListField` (:class:`~mongoengine.ReferenceField`).
 
 
 .. warning::

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -656,8 +656,7 @@ class ReferenceField(BaseField):
       * NULLIFY     - Updates the reference to null.
       * CASCADE     - Deletes the documents associated with the reference.
       * DENY        - Prevent the deletion of the reference object.
-      * PULL        - Pull the reference from a :class:`~mongoengine.ListField`
-                      of references
+      * PULL        - Pull the reference from a :class:`~mongoengine.ListField` of references
 
     Alternative syntax for registering delete rules (useful when implementing
     bi-directional delete rules)

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -656,6 +656,8 @@ class ReferenceField(BaseField):
       * NULLIFY     - Updates the reference to null.
       * CASCADE     - Deletes the documents associated with the reference.
       * DENY        - Prevent the deletion of the reference object.
+      * PULL        - Pull the reference from a :class:`~mongoengine.ListField`
+                      of references
 
     Alternative syntax for registering delete rules (useful when implementing
     bi-directional delete rules)

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -10,7 +10,7 @@ from bson.code import Code
 from mongoengine import signals
 
 __all__ = ['queryset_manager', 'Q', 'InvalidQueryError',
-           'DO_NOTHING', 'NULLIFY', 'CASCADE', 'DENY']
+           'DO_NOTHING', 'NULLIFY', 'CASCADE', 'DENY', 'PULL']
 
 
 # The maximum number of items to display in a QuerySet.__repr__
@@ -21,6 +21,7 @@ DO_NOTHING = 0
 NULLIFY = 1
 CASCADE = 2
 DENY = 3
+PULL = 4
 
 
 class DoesNotExist(Exception):
@@ -1319,6 +1320,10 @@ class QuerySet(object):
                 document_cls.objects(**{field_name + '__in': self}).update(
                         safe_update=safe,
                         **{'unset__%s' % field_name: 1})
+            elif rule == PULL:
+                document_cls.objects(**{field_name + '__in': self}).update(
+                        safe_update=safe,
+                        **{'pull_all__%s' % field_name: self})
 
         self._collection.remove(self._query, safe=safe)
 


### PR DESCRIPTION
Using reverse_delete_rule of NULIFY or CASCADE on ListField(ReferenceField) may produce undesired results. The former will Nullify the entire field (with all the other references found in the list) while the latter will delete the entire document.

This adds another reverse_delete_rule: PULL. It just removes the reference from the list (keeping all other references intact).
