### PR TITLE
unicode fixes

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -49,10 +49,13 @@ class StringField(BaseField):
         super(StringField, self).__init__(**kwargs)
 
     def to_python(self, value):
-        return unicode(value)
+        if isinstance(value, unicode):
+            return value
+        else:
+            return value.decode('utf-8')
 
     def validate(self, value):
-        if not isinstance(value, (str, unicode)):
+        if not isinstance(value, basestring):
             self.error('StringField only accepts string values')
 
         if self.max_length is not None and len(value) > self.max_length:


### PR DESCRIPTION
If the value of a StringField is already unicode, StringField.to_python() fails.

This patch fixes conversion of StringField value to unicode, and updates an outdated (str, unicode) check.
