### PR TITLE
Fixes for __ne operator in IntField and FloatField

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -167,6 +167,9 @@ class IntField(BaseField):
             self.error('Integer value is too large')
 
     def prepare_query_value(self, op, value):
+        if value is None:
+            return value
+        
         return int(value)
 
 
@@ -194,6 +197,9 @@ class FloatField(BaseField):
             self.error('Float value is too large')
 
     def prepare_query_value(self, op, value):
+        if value is None:
+            return value
+        
         return float(value)
 
 


### PR DESCRIPTION
for this test case:

``` python
from mongoengine import *
from mongoengine import register_connection

register_connection('default', name='test')

class TestDocument(Document):
    val = IntField()

TestDocument.drop_collection()

TestDocument(val=None).save()
TestDocument(val=1).save()


doc = TestDocument.objects(val__ne=None).first()
print doc
```
