### PR TITLE
Force a cast from tuple to list on meta['indexes'] & initialize direction variable

### DIFF
--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -704,7 +704,7 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
             meta['queryset_class'] = manager.queryset_class
         new_class.objects = manager
 
-        indicies = meta['indexes'] + abstract_base_indexes
+        indicies = [meta['indexes']] + abstract_base_indexes
         user_indexes = [QuerySet._build_index_spec(new_class, spec)
                         for spec in indicies] + base_indexes
         new_class._meta['indexes'] = user_indexes

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -492,6 +492,7 @@ class QuerySet(object):
             spec = {'fields': spec}
 
         index_list = []
+        direction = None
         use_types = doc_cls._meta.get('allow_inheritance', True)
         for key in spec['fields']:
             # Get ASCENDING direction from +, DESCENDING from -, and GEO2D from *


### PR DESCRIPTION
I'm using mongoengine with pip and I get this error since I upgrade mongoengine (from a very old version forked by metzlar):

```
Traceback (most recent call last):
  File "/opt/pypy-1.7/lib-python/2.7/unittest/case.py", line 318, in run
    testMethod()
  File "/var/lib/jenkins/jobs/Xxx/workspace/.env/site-packages/nose-1.1.2-py2.7.egg/nose/loader.py", line 390, in loadTestsFromName
    addr.filename, addr.module)
  File "/var/lib/jenkins/jobs/Xxx/workspace/.env/site-packages/nose-1.1.2-py2.7.egg/nose/importer.py", line 39, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/var/lib/jenkins/jobs/Xxx/workspace/.env/site-packages/nose-1.1.2-py2.7.egg/nose/importer.py", line 86, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/var/lib/jenkins/jobs/Xxx/workspace/xxx/auth/__init__.py", line 6, in <module>
    from xxx.auth import views
  File "/var/lib/jenkins/jobs/Xxx/workspace/xxx/auth/views.py", line 16, in <module>
    from xxx.social.client import Client
  File "/var/lib/jenkins/jobs/Xxx/workspace/xxx/social/__init__.py", line 9, in <module>
    from xxx.social import views
  File "/var/lib/jenkins/jobs/Xxx/workspace/xxx/social/views.py", line 11, in <module>
    from xxx.social.models import CheckIn, SocialQuery
  File "/var/lib/jenkins/jobs/Xxx/workspace/xxx/social/models.py", line 7, in <module>
    class CheckIn(db.Document):
  File "/var/lib/jenkins/jobs/Xxx/workspace/.env/site-packages/mongoengine-0.6.13-py2.7.egg/mongoengine/base.py", line 707, in __new__
    indicies = meta['indexes'] + abstract_base_indexes
TypeError: unsupported operand type(s) for +: 'tuple' and 'list'
```

To fix it I casted meta['indexes'] to list.

I don't know if it's the best way to do it or perhaps a check like:

``` python
if type(meta['indexes'] == tuple):
    meta['indexes'] = list(meta['indexes'])
```

But I don't see the point of this check.

Furthermore, running the tests (of mongoengine) there is a variable called `direction` that is not initialized. I initialized it to None, but I get 4 more failures.
