### PR TITLE
Bug fix for unicode issues in queryset

### DIFF
--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -702,7 +702,7 @@ class QuerySet(object):
                 cleaned_fields = []
                 for field in fields:
                     append_field = True
-                    if isinstance(field, str):
+                    if isinstance(field, basestring):
                         parts.append(field)
                         append_field = False
                     else:
@@ -1373,7 +1373,7 @@ class QuerySet(object):
                 cleaned_fields = []
                 for field in fields:
                     append_field = True
-                    if isinstance(field, str):
+                    if isinstance(field, basestring):
                         # Convert the S operator to $
                         if field == 'S':
                             field = '$'


### PR DESCRIPTION
replaced the two remaining isinstance(_, str) with basestring
fixes a bug where unicode is being treated like a field.
