### PR TITLE
UUID field fix, small typo, but breaks non-binary UUID field.

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -1327,7 +1327,7 @@ class UUIDField(BaseField):
         super(UUIDField, self).__init__(**kwargs)
 
     def to_python(self, value):
-        if not self.binary:
+        if not self._binary:
             if not isinstance(value, basestring):
                 value = unicode(value)
             return uuid.UUID(value)


### PR DESCRIPTION
Last UUID field change break it! Probably some tests would be useful to prevent this. Please release new version as soon as possible because current version simply does not work if you have UUID fields in your documents.
