### PR TITLE
Unit test for issue #561.

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1350,6 +1350,24 @@ class DocumentTest(unittest.TestCase):
         doc.f = 6
         doc.save()
 
+    def test_dynamic_embedded_db_field_can_update(self):
+
+        class SubDoc(DynamicEmbeddedDocument):
+            val = IntField()
+
+        class Doc(DynamicDocument):
+            pass
+
+        Doc.drop_collection()
+
+        doc = Doc()
+        doc.e = SubDoc(val=15)
+        doc.save()
+
+        doc = Doc.objects.first()
+        doc.f = 6
+        doc.save()
+
     def test_save(self):
         """Ensure that a document may be saved in the database.
         """

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1332,6 +1332,24 @@ class DocumentTest(unittest.TestCase):
         doc.validate()
         self.assertEquals([None, 'e'], doc._data.keys())
 
+    def test_embedded_db_field_can_update(self):
+
+        class SubDoc(EmbeddedDocument):
+            val = IntField()
+
+        class Doc(DynamicDocument):
+            pass
+
+        Doc.drop_collection()
+
+        doc = Doc()
+        doc.e = SubDoc(val=15)
+        doc.save()
+
+        doc = Doc.objects.first()
+        doc.f = 6
+        doc.save()
+
     def test_save(self):
         """Ensure that a document may be saved in the database.
         """


### PR DESCRIPTION
89f6a54 shows how re-saving a dynamic document with an embedded document in it crashes mongoengine.

3c111f6 shows that this is not an issue when the embedded document is dynamic as well.
