### PR TITLE
Raw MongoDB Query Parser

### DIFF
--- a/.arcconfig
+++ b/.arcconfig
@@ -1,0 +1,4 @@
+{   
+  "project_id" : "MongoEngine", 
+  "conduit_uri" : "http://infra1.corp.contextlogic.com/"    
+}

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -929,6 +929,7 @@ class BaseDocument(object):
             data[name] = field.to_mongo(self._data.get(name, None))
         return data
 
+
     @classmethod
     def _get_collection_name(cls):
         """Returns the collection name for this class.

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -512,7 +512,10 @@ class DynamicEmbeddedDocument(EmbeddedDocument):
 
     @classmethod
     def update(cls, spec, document, upsert=False, multi=True, **kwargs):
-        document = cls._transform_value(document, cls)
+        # updates behave like set instead of find (None)... this is relevant for
+        # setting list values since you're setting the value of the whole list,
+        # not an element inside the list (like in find)
+        document = cls._transform_value(document, cls, op='$set')
         spec = cls._transform_value(spec, cls)
 
         # handle queries with inheritance

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -4,13 +4,14 @@ from bson.dbref import DBRef
 
 from mongoengine import signals
 from base import (DocumentMetaclass, TopLevelDocumentMetaclass, BaseDocument,
-                  BaseDict, BaseList)
+                  BaseDict, BaseList, ValidationError, get_document)
 from queryset import OperationError
 from connection import get_db, DEFAULT_CONNECTION_NAME
+from bson import SON, ObjectId
+
 
 __all__ = ['Document', 'EmbeddedDocument', 'DynamicDocument',
            'DynamicEmbeddedDocument', 'OperationError', 'InvalidCollectionError']
-
 
 class InvalidCollectionError(Exception):
     pass
@@ -407,6 +408,280 @@ class DynamicEmbeddedDocument(EmbeddedDocument):
         field_name = args[0]
         setattr(self, field_name, None)
 
+    @classmethod
+    def pk_field(cls):
+        return cls._fields[cls._meta['id_field']]
+
+    @classmethod
+    def _pymongo(cls):
+        return cls.objects._collection
+
+
+    @classmethod
+    def find_raw(cls, spec, fields=None, skip=0, limit=0, sort=None,
+                 slave_ok=False, find_one=False, **kwargs):
+        # transform query
+        spec = cls._transform_value(spec, cls)
+
+        # transform fields to include
+        if isinstance(fields, list):
+            fields = [cls._transform_key(f, cls)[0] for f in fields]
+        elif isinstance(fields, dict):
+            fields = dict([[cls._transform_key(f, cls)[0], fields[f]] for f in
+                           fields])
+
+        # transform sort
+        if sort:
+            new_sort = []
+            for f, dir in sort:
+                f, _ = cls._transform_key(f, cls)
+                new_sort.append((f, dir))
+
+            sort = new_sort
+
+        if slave_ok:
+            read_preference = pymongo.ReadPreference.SECONDARY
+        else:
+            read_preference = pymongo.ReadPreference.PRIMARY
+
+
+        if find_one:
+            return cls._pymongo().find_one(spec, fields, skip=skip, sort=sort,
+                                   read_preference=read_preference, **kwargs)
+        else:
+            return cls._pymongo().find(spec, fields, skip=skip, limit=limit,
+                                   sort=sort, read_preference=read_preference,
+                                   **kwargs)
+
+    @classmethod
+    def find(cls, spec, fields=None, skip=0, limit=0, sort=None,
+             slave_ok=False, **kwargs):
+        cur = cls.find_raw(spec, fields, skip, limit, sort, **kwargs)
+
+        return [cls._from_son(d) for d in cur]
+
+    @classmethod
+    def find_one(cls, spec, fields=None, skip=0, sort=None,
+                 slave_ok=False, **kwargs):
+        d = cls.find_raw(spec, fields, skip=skip, sort=sort,
+                         slave_ok=slave_ok, find_one=True, **kwargs)
+
+        if d:
+            return cls._from_son(d)
+        else:
+            return None
+
+    def update_one(self, document, spec=None, upsert=False, **kwargs):
+        ops = {}
+
+        for operator, operand in document.iteritems():
+            # safety check - these updates should only have atomic ops in them
+            if operator[0] != '$':
+                raise ValueError("All updates should be atomic operators")
+
+            if '.' not in operand:
+                for field, new_val in operand.iteritems():
+                    # for now, skip doing in-memory sets on dicts
+                    if '.' in field:
+                        continue
+
+                    if operator == '$set':
+                        ops[field] = new_val
+                    elif operator == '$unset':
+                        ops[field] = None
+                    elif operator == '$inc':
+                        ops[field] = self[field] + new_val
+                    elif operator == '$push':
+                        ops[field] = self[field][:] + [new_val]
+                    elif operator == '$pushAll':
+                        ops[field] = self[field][:] + new_val
+                    elif operator == '$addToSet':
+                        if '$each' in new_val:
+                            vals_to_add = new_val['$each']
+                        else:
+                            vals_to_add = [new_val]
+
+                        for val in vals_to_add:
+                            if new_val not in self[field]:
+                                ops[field] = self[field][:] + [val]
+
+        document = self._transform_value(document, type(self))
+        query_spec = {'_id': self.id}
+
+        if spec:
+            spec = self._transform_value(spec, type(self))
+            query_spec.update(spec)
+
+        result = self._pymongo().update(query_spec, document,
+                                        upsert=upsert, safe=True, **kwargs)
+
+        # do in-memory updates on the object if the query succeeded
+        if result['n'] == 1:
+            for field, new_val in ops.iteritems():
+                self[field] = new_val
+
+        return result
+
+    def set(self, **kwargs):
+        return self.update_one({'$set': kwargs})
+
+    def inc(self, **kwargs):
+        return self.update_one({'$inc': kwargs})
+
+    def push(self, **kwargs):
+        return self.update_one({'$push': kwargs})
+
+    def add_to_set(self, **kwargs):
+        return self.update_one({'$addToSet': kwargs})
+
+    def _transform_query(self, query, validate=True):
+        cls = type(self)
+        return cls._transform_value(query, cls, validate=validate)
+
+    @staticmethod
+    def _transform_value(value, context, op=None, validate=True):
+        from fields import DictField, EmbeddedDocumentField, ListField, \
+                            ObjectIdField
+
+        VALIDATE_OPS = ['$set', '$inc', None]
+        LIST_VALIDATE_OPS = ['$addToSet', '$push', '$pull']
+        LIST_VALIDATE_ALL_OPS = ['$pushAll', '$pullAll', '$each']
+        NO_VALIDATE_OPS = ['$unset', '$pop', '$rename', '$bit']
+
+        # recurse on dict, unless we're at a DictField
+        if isinstance(value, dict) and not isinstance(context, DictField):
+            transformed_value = SON()
+
+            for key, subvalue in value.iteritems():
+                if key[0] == '$':
+                    op = key
+
+                new_key, value_context = Document._transform_key(key, context)
+
+                transformed_value[new_key] = \
+                    Document._transform_value(subvalue, value_context,
+                                              op, validate)
+
+            return transformed_value
+        # else, validate & return
+        else:
+            # automatically encode ObjectIds (they're often strings)
+            if isinstance(context, ObjectIdField):
+                value = ObjectId(value)
+
+            if validate:
+                if op in VALIDATE_OPS:
+                    context.validate(value)
+                elif op in LIST_VALIDATE_OPS:
+                    context.field.validate(value)
+                elif op in LIST_VALIDATE_ALL_OPS:
+                    for entry in value:
+                        context.field.validate(entry)
+                elif op not in NO_VALIDATE_OPS:
+                    raise ValidationError("Unknown atomic operator %s" % op)
+
+            # handle EmbeddedDocuments
+            if isinstance(value, BaseDocument):
+                value = value.to_mongo()
+
+            # handle lists (force to_mongo() everything if it's a list of docs)
+            elif isinstance(context, ListField) and \
+               isinstance(context.field, EmbeddedDocumentField):
+                value = [d.to_mongo() for d in value]
+
+            # handle dicts (just blindly to_mongo() anything that'll take it)
+            elif isinstance(context, DictField):
+                for k, v in value.iteritems():
+                    if isinstance(v, BaseDocument):
+                        value[k] = v.to_mongo()
+
+            return value
+
+    @staticmethod
+    def _transform_key(key, context, prefix=''):
+        from fields import BaseField, DictField, ListField, \
+                            EmbeddedDocumentField, ArbitraryField
+
+        parts = key.split('.', 1)
+        first_part = parts[0]
+
+        if len(parts) > 1:
+            rest = parts[1]
+        else:
+            rest = None
+
+        # a key as a digit means a list index... set context as the list's value
+        if first_part.isdigit():
+            if isinstance(context.field, basestring):
+                context = get_document(context.field)
+            elif isinstance(context.field, BaseField):
+                context = context.field
+
+        if first_part == '_id':
+            context = context.pk_field()
+
+        # atomic ops, digits (list indexes), or _ids get no processing
+        if first_part[0] == '$' or first_part.isdigit() or first_part == '_id':
+            if prefix:
+                new_prefix = "%s.%s" % (prefix, first_part)
+            else:
+                new_prefix = first_part
+
+            if rest:
+                return Document._transform_key(rest, context, prefix=new_prefix)
+            else:
+                return new_prefix, context
+
+
+        def is_subclass_or_instance(obj, parent):
+            try:
+                if issubclass(obj, parent):
+                    return True
+            except TypeError:
+                if isinstance(obj, parent):
+                    return True
+
+            return False
+
+        field = None
+
+        if is_subclass_or_instance(context, BaseDocument):
+            field = context._fields.get(first_part, None)
+        elif is_subclass_or_instance(context, EmbeddedDocumentField):
+            field = context.document_type._fields.get(first_part, None)
+        elif is_subclass_or_instance(context, ListField):
+            if is_subclass_or_instance(context.field, basestring):
+                field = get_document(context.field)
+            elif is_subclass_or_instance(context.field, BaseField):
+                field = context.field
+            else:
+                raise ValueError("Can't parse field %s" % first_part)
+        # if we hit a DictField, values can be anything, so use the sentinal
+        # ArbitraryField value (I prefer this over None, since None can be
+        # introduced in other ways that would be considered errors & should not
+        # be silently ignored)
+        elif is_subclass_or_instance(context, DictField):
+            field = ArbitraryField()
+        elif is_subclass_or_instance(context, ArbitraryField):
+            field = context
+
+        if not field:
+            raise ValueError("Can't find field %s" % first_part)
+
+        if is_subclass_or_instance(field, ArbitraryField):
+            db_field = first_part
+        else:
+            db_field = field.db_field
+
+        if prefix:
+            result = "%s.%s" % (prefix, db_field)
+        else:
+            result = db_field
+
+        if rest:
+            return Document._transform_key(rest, field, prefix=result)
+        else:
+            return result, field
 
 class MapReduceDocument(object):
     """A document returned from a map/reduce query.

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -551,12 +551,16 @@ class DynamicEmbeddedDocument(EmbeddedDocument):
         from fields import DictField, EmbeddedDocumentField, ListField, \
                             ObjectIdField
 
-        VALIDATE_OPS = ['$set', '$inc', None]
+        VALIDATE_OPS = ['$set', '$inc', None, '$eq', '$gte', '$lte', '$lt',
+                        '$gt', '$ne']
         LIST_VALIDATE_OPS = ['$addToSet', '$push', '$pull']
         LIST_VALIDATE_ALL_OPS = ['$pushAll', '$pullAll', '$each', '$in',
                                  '$nin', '$all']
         NO_VALIDATE_OPS = ['$unset', '$pop', '$rename', '$bit',
-                           '$all', '$and', '$or', '$exists']
+                           '$all', '$and', '$or', '$exists', '$mod',
+                           '$elemMatch', '$size', '$type', '$not', '$returnKey',
+                           '$maxScan', '$orderby', '$explain', '$snapshot',
+                           '$max', '$min', '$showDiskLoc', '$hint', '$comment']
 
         # recurse on dict, unless we're at a DictField
         if isinstance(value, dict) and not isinstance(context, DictField):

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -33,10 +33,24 @@ __all__ = ['StringField', 'IntField', 'FloatField', 'BooleanField',
            'DecimalField', 'ComplexDateTimeField', 'URLField', 'DynamicField',
            'GenericReferenceField', 'FileField', 'BinaryField',
            'SortedListField', 'EmailField', 'GeoPointField', 'ImageField',
-           'SequenceField', 'UUIDField', 'GenericEmbeddedDocumentField']
+           'SequenceField', 'UUIDField', 'GenericEmbeddedDocumentField', 'ArbitraryField']
 
 RECURSIVE_REFERENCE_CONSTANT = 'self'
 
+class ArbitraryField(BaseField):
+    """
+        This is meant as a sentinal value in query parsing for cases where the
+        value can't be validated and anything should be accepted (e.g. inside
+        DictFields)
+
+        Don't use this to actually design a schema.
+    """
+
+    def validate(self, value):
+        return True
+
+    def to_python(self, value):
+        return value
 
 class StringField(BaseField):
     """A unicode string field.

--- a/tests/custom_queries.py
+++ b/tests/custom_queries.py
@@ -259,6 +259,27 @@ class DocumentTest(unittest.TestCase):
         self.assertEquals(p1.age, 10)
         self.assertEquals(p1.name, None)
 
+    def testQueryIn(self):
+        query = {'_id': {'$in': [ObjectId(), ObjectId(), ObjectId()] } }
+        self.assertEquals(self.User._transform_value(query, self.User), query)
+
+    def testAutoObjId(self):
+        obj_ids = [ObjectId(), ObjectId(), ObjectId()]
+        in_query = {'_id': {'$in': [str(o) for o in obj_ids]}}
+
+        out_query = self.User._transform_value(in_query, self.User)
+
+        self.assertEquals(out_query['_id']['$in'], obj_ids)
+
+        u1 = self.User(id=ObjectId())
+        u1.save()
+        u2 = self.User(id=ObjectId())
+        u2.save()
+
+        users = self.User.find({'_id': {'$in': [str(u1.id), str(u2.id)]}})
+
+        self.assertEquals(users, [u1, u2])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/custom_queries.py
+++ b/tests/custom_queries.py
@@ -558,5 +558,28 @@ class DocumentTest(unittest.TestCase):
         p = self.Person.find_one({'_id': u.id})
         self.assertEquals(p.id_list, [new_id3, new_id4])
 
+    def testListUpdate(self):
+        u = self.Person(id=ObjectId(), some_id=ObjectId())
+        u.save()
+
+        ret = self.Person.update({'some_id': u.some_id}, {'some_id': u.some_id, 'number_list': range(3)}, multi=False)
+        self.assertEquals(ret['n'], 1)
+
+        u.reload()
+        self.assertEquals(u.number_list, range(3))
+
+        ret = self.Person.update({'some_id': u.some_id}, {'$set': {'number_list': range(5)}}, multi=False)
+        self.assertEquals(ret['n'], 1)
+
+        u.reload()
+        self.assertEquals(u.number_list, range(5))
+
+        ret = self.Person.update({'some_id': u.some_id}, {'some_id': u.some_id, 'name': 'Adam'}, multi=False)
+        self.assertEquals(ret['n'], 1)
+
+        u.reload()
+        self.assertEquals(u.number_list, [])
+        self.assertEquals(u.name, "Adam")
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/custom_queries.py
+++ b/tests/custom_queries.py
@@ -32,6 +32,7 @@ class DocumentTest(unittest.TestCase):
 
         class User(Document):
             id = ObjectIdField(primary_key=True)
+            name = StringField()
 
         self.Person = Person
         self.Colour = Colour
@@ -280,6 +281,29 @@ class DocumentTest(unittest.TestCase):
 
         self.assertEquals(users, [u1, u2])
 
+    def testOnlyId(self):
+        p = self.Person(name="Adam")
+        p.save()
+
+        p1 = self.Person.find_one({'name': 'Adam'}, fields=['id'])
+        self.assertEquals(p1.name, None)
+        self.assertEquals(p1.id, p.id)
+
+        p2 = self.Person.find_one({'name': 'Adam'}, fields=['_id'])
+        self.assertEquals(p2.name, None)
+        self.assertEquals(p2.id, p.id)
+
+        # test where ID is defined explicitly
+        u = self.User(name="Adam", id=ObjectId())
+        u.save()
+
+        u2 = self.User.find_one({'name': 'Adam'}, fields=['_id'])
+        self.assertEquals(u2.name, None)
+        self.assertEquals(u2.id, u.id)
+
+        u2 = self.User.find_one({'name': 'Adam'}, fields=['id'])
+        self.assertEquals(u2.name, None)
+        self.assertEquals(u2.id, u.id)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/custom_queries.py
+++ b/tests/custom_queries.py
@@ -1,0 +1,264 @@
+import pymongo
+import unittest
+import warnings
+
+from mongoengine import *
+from mongoengine.connection import _get_db
+
+from bson import ObjectId
+
+class DocumentTest(unittest.TestCase):
+
+    def setUp(self):
+        connect(db='mongoenginetest')
+        self.db = _get_db()
+
+        class Person(Document):
+            meta = {'allow_inheritance': False}
+            name = StringField()
+            age = IntField(db_field='a')
+            favourite_colour = EmbeddedDocumentField("Colour", db_field="c")
+            other_colours = ListField(EmbeddedDocumentField("Colour"), db_field="o")
+            number_list = ListField(IntField())
+            arbitrary_dict = DictField()
+            some_id = ObjectIdField()
+
+        class Colour(EmbeddedDocument):
+            meta = {'allow_inheritance': False}
+            name = StringField(db_field='n')
+
+            def __str__(self):
+                return self.name
+
+        class User(Document):
+            id = ObjectIdField(primary_key=True)
+
+        self.Person = Person
+        self.Colour = Colour
+        self.User = User
+
+    def tearDown(self):
+        self.Person.objects.delete()
+
+    def testInc(self):
+        p = self.Person(name="Adam", age=12)
+        p.save()
+
+        self.assertEqual(p.name, "Adam")
+
+        p.inc(age=1)
+        self.assertEqual(p.age, 13)
+        self.assertEqual(p.name, "Adam")
+        p.reload()
+        self.assertEqual(p.age, 13)
+        self.assertEqual(p.name, "Adam")
+
+        p.inc(age=-3)
+        self.assertEqual(p.age, 10)
+        p.reload()
+        self.assertEqual(p.age, 10)
+
+        p.update_one({'$inc': {'age': 7}})
+        self.assertEqual(p.name, "Adam")
+        self.assertEqual(p.age, 17)
+        p.reload()
+        self.assertEqual(p.name, "Adam")
+        self.assertEqual(p.age, 17)
+
+    def testSet(self):
+        p = self.Person(name="Adam", age=12)
+        p.save()
+
+        self.assertEqual(p.name, "Adam")
+        p.set(age=15)
+        self.assertEqual(p.name, "Adam")
+        self.assertEqual(p.age, 15)
+        p.reload()
+        self.assertEqual(p.age, 15)
+        self.assertEqual(p.name, "Adam")
+
+        p.set(age=19, name="Josh")
+        self.assertEqual(p.age, 19)
+        self.assertEqual(p.name, "Josh")
+        p.reload()
+        self.assertEqual(p.age, 19)
+        self.assertEqual(p.name, "Josh")
+
+    def testAddToSet(self):
+        blue = self.Colour(name="Blue")
+        red = self.Colour(name="Red")
+        yellow = self.Colour(name="Yellow")
+        p = self.Person(name="Adam", other_colours=[blue, yellow])
+        p.save()
+
+        self.assertEqual([c.name for c in p.other_colours], ['Blue', 'Yellow'])
+
+        p.add_to_set(other_colours=blue)
+        self.assertEqual([c.name for c in p.other_colours], ['Blue', 'Yellow'])
+        p.reload()
+        self.assertEqual([c.name for c in p.other_colours], ['Blue', 'Yellow'])
+
+        p.add_to_set(other_colours=red)
+        self.assertEqual([c.name for c in p.other_colours], ['Blue', 'Yellow', 'Red'])
+        p.reload()
+        self.assertEqual([c.name for c in p.other_colours], ['Blue', 'Yellow', 'Red'])
+
+    def testSetEmbedded(self):
+        blue = self.Colour(name="Blue")
+        p = self.Person(name="Adam", age=12)
+        p.save()
+
+        self.assertEqual(p.favourite_colour, None)
+        p.set(favourite_colour=blue)
+        self.assertEqual(p.favourite_colour.name, blue.name)
+        self.assertTrue(isinstance(p.favourite_colour, self.Colour))
+        p.reload()
+        self.assertEqual(p.favourite_colour.name, "Blue")
+
+    def testInvalidField(self):
+        p = self.Person(name="Adam", age=12)
+        p.save()
+
+        self.assertRaises(ValueError, p.set, doesntexist='foobar')
+
+    def testTransformQuery(self):
+        query = {'$set': {'name': 'Chu', 'age': 20}}
+        result = self.Person._transform_value(query, self.Person)
+
+        self.assertEqual(result, {'$set': {'name': 'Chu', 'a': 20}})
+
+    def testTransformQueryEmbedded(self):
+        blue = self.Colour(name='Blue')
+        query = {'$set': {'name': 'Chu', 'age': 20, 'favourite_colour': blue}}
+        result = self.Person._transform_value(query, self.Person)
+
+        self.assertEqual(set(result['$set'].keys()), set(['name', 'a', 'c']))
+
+        self.assertEqual(result['$set']['name'], 'Chu')
+        self.assertEqual(result['$set']['c'], {'n': 'Blue'})
+
+    def testTransformQueryList(self):
+        blue = self.Colour(name='Blue')
+        red = self.Colour(name='Red')
+        query = {'$set': {'name': 'Chu', 'age': 20, 'other_colours': [red, blue]}}
+        result = self.Person._transform_value(query, self.Person)
+
+        self.assertEqual(set(result['$set'].keys()), set(['name', 'a', 'o']))
+
+        self.assertEqual(result['$set']['name'], 'Chu')
+        self.assertEqual(result['$set']['o'], [{'n': 'Red'}, {'n': 'Blue'}])
+
+    def testTransformQueryListIndex(self):
+        blue = self.Colour(name='Blue')
+        query = {'$set': {'other_colours.1': blue}}
+        result = self.Person._transform_value(query, self.Person)
+
+        self.assertEqual(result, {'$set': {'o.1': {'n': 'Blue'}}})
+
+        query = {'$set': {'other_colours.1.name': 'Red'}}
+        result = self.Person._transform_value(query, self.Person)
+
+        self.assertEqual(result, {'$set': {'o.1.n': 'Red'}})
+
+    def testValidateQuery(self):
+        p = self.Person(name="Adam", age=12)
+        p.save()
+
+        self.assertRaises(ValidationError, p.set, age="hello")
+
+    def testDictEncoding(self):
+        p = self.Person(name="Adam", age=21)
+        p.save()
+        val = {'x': 4, 'c': self.Colour(name="Blue")}
+        p.set(arbitrary_dict=val)
+
+        p.reload()
+        self.assertEqual(p.arbitrary_dict, val)
+
+        query = {'$set': {'arbitrary_dict.x': 42,
+                          'age': 12,
+                          'arbitrary_dict.c.n': 'Red'}}
+        transformed = self.Person._transform_value(query, self.Person)
+
+        self.assertEqual(transformed['$set']['arbitrary_dict.x'], 42)
+        self.assertEqual(transformed['$set']['arbitrary_dict.c.n'], 'Red')
+        self.assertEqual(transformed['$set']['a'], 12)
+        self.assertEqual(len(transformed), 1)
+        self.assertEqual(len(transformed['$set']), 3)
+
+        p.update_one(query)
+        self.assertEqual(p.age, 12)
+        self.assertEqual(p.arbitrary_dict['x'], 4)
+        self.assertEqual(p.arbitrary_dict['c']['n'], "Blue")
+
+        p.reload()
+        self.assertEqual(p.age, 12)
+        self.assertEqual(p.arbitrary_dict['x'], 42)
+        self.assertEqual(p.arbitrary_dict['c']['n'], "Red")
+
+    def testObjectIdEncoding(self):
+        p = self.Person(some_id='0' * 24)
+        p.save()
+
+        self.assertEqual(p.find({'some_id': '0' * 24}), [p])
+
+        p.reload()
+
+        self.assertEqual(p.some_id, ObjectId('0' * 24))
+
+    def testDocumentIds(self):
+        user = self.User(id=ObjectId())
+        user.save()
+        uid = user.id
+
+        self.assertEqual(user.find({'_id': uid}), [user])
+        self.assertEqual(user.find_one({'_id': uid}), user)
+
+        p = self.Person()
+        p.save()
+
+        self.assertEqual(p.find({'_id': p.id}), [p])
+
+    def testSort(self):
+        p1 = self.Person(age=10)
+        p1.save()
+        p2 = self.Person(age=15)
+        p2.save()
+        p3 = self.Person(age=20)
+        p3.save()
+
+        self.assertEquals(self.Person.find({}, sort=[('age', 1)]), [p1, p2, p3])
+        self.assertEquals(self.Person.find({}, sort=[('age', -1)]), [p3, p2, p1])
+        self.assertRaises(TypeError, self.Person.find, {}, sort=[('age', 0)])
+        self.assertRaises(ValueError, self.Person.find, {}, sort=['age'])
+        self.assertRaises(ValueError, self.Person.find, {}, sort='age')
+
+    def testIncludeFields(self):
+        p = self.Person(age=10, name="Adam")
+        p.save()
+
+        p1 = self.Person.find_one({'age': 10})
+        self.assertEquals(p1, p)
+
+        p1 = self.Person.find_one({'age': 10}, fields=['age'])
+        self.assertEquals(p1.age, 10)
+        self.assertEquals(p1.name, None)
+
+        p1 = self.Person.find_one({'age': 10}, fields=['age', 'name'])
+        self.assertEquals(p1, p)
+
+        p1 = self.Person.find_one({'age': 10}, fields={'age': 0})
+        self.assertEquals(p1.age, None)
+        self.assertEquals(p1.name, 'Adam')
+
+        p1 = self.Person.find_one({'age': 10}, fields={'name': 0})
+        self.assertEquals(p1.age, 10)
+        self.assertEquals(p1.name, None)
+
+        p1 = self.Person.find_one({'age': 10}, fields={'age': 1})
+        self.assertEquals(p1.age, 10)
+        self.assertEquals(p1.name, None)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Ok, here's the bundle of changes related to the query parser you wanted. Don't have full docs written for them yet, but I'm working on some internally that I can share when they're done. Basically the goal was to provide an alternative to QuerySet that allows expression of any query MongoDB can support and lower-level access to pymongo when it's needed.

Supports validation, db_name transformation, and updating the document in memory (for a few operator types; more could be added).

Getting unit test fails because of documents not being registered (I'm guessing my tests just have to be changed to work with whatever the latest version of MongoEngine is, but if there are more fundamental incompatibilities, let me know and I can try to help debug).
