### PR TITLE
Added note to Django setup instructions.

### DIFF
--- a/docs/django.rst
+++ b/docs/django.rst
@@ -10,6 +10,10 @@ In your **settings.py** file, ignore the standard database settings (unless you
 also plan to use the ORM in your project), and instead call
 :func:`~mongoengine.connect` somewhere in the settings module.
 
+Note: remove ``django.contrib.sites`` from ``INSTALLED_APPS`` in settings.py,
+to avoid ``ImproperlyConfigured: settings.DATABASES is improperly configured``
+error.
+
 Authentication
 ==============
 MongoEngine includes a Django authentication backend, which uses MongoDB. The


### PR DESCRIPTION
By using 'django.contrib.sites' in INSTALLED_APPS returns an error because Sites framework tries to use database.
