### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,9 @@ Dependencies
 
 Examples
 ========
-Some simple examples of what MongoEngine code looks like::
+Some simple examples of what MongoEngine code looks like
+
+.. code-block:: python
 
     class BlogPost(Document):
         title = StringField(required=True, max_length=200)


### PR DESCRIPTION
Syntax highlighting of the Python snippets, now that Github highlight reStructuredText code blocks (https://github.com/github/markup/pull/92#issuecomment-7116745)
